### PR TITLE
Adjust highlighting selected items

### DIFF
--- a/src/ARte/users/jinja2/users/components/artworks-list.jinja2
+++ b/src/ARte/users/jinja2/users/components/artworks-list.jinja2
@@ -13,7 +13,6 @@
             {% if selected %}
                 "{{selected}}".split(",").forEach(function(id){
                     artworks[id] = id
-                    $("#artwork-"+id).css('background-color', "green");
                     $("#artwork-"+id).css("border-bottom","3px solid #a6a6a6");
                 })
             {% endif %}

--- a/src/ARte/users/jinja2/users/components/artworks-list.jinja2
+++ b/src/ARte/users/jinja2/users/components/artworks-list.jinja2
@@ -13,20 +13,23 @@
             {% if selected %}
                 "{{selected}}".split(",").forEach(function(id){
                     artworks[id] = id
-                    $("#artwork-"+id).css('background-color', "rgb(217,217,217)");
+                    $("#artwork-"+id).css('background-color', "green");
+                    $("#artwork-"+id).css("border-bottom","3px solid #a6a6a6");
                 })
             {% endif %}
 
             $('.repository-item').click(function(){
+                console.log("cl");
                 let elementId = $(this).attr('id').split('-')[1];
                 let sectionId = $(this).parent().attr('id');
                 
                 // reset background
-                if($(this).css('background-color') == "rgb(217, 217, 217)"){
-                    $(this).css('background-color', "rgb(255,255,255)");
+                if($(this).css('border-bottom-style') != "none"){
+                    console.log("ASDF");
+                    $(this).css("border-bottom","none");
                     delete artworks[elementId]
                 }else{
-                    $(this).css('background-color', "rgb(255,0,0)");
+                    $(this).css("border-bottom","3px solid #a6a6a6");
                     artworks[elementId] = elementId
                 }
                 str_artworks = ""

--- a/src/ARte/users/jinja2/users/components/repository-list.jinja2
+++ b/src/ARte/users/jinja2/users/components/repository-list.jinja2
@@ -9,7 +9,7 @@
         <script>
             {%if selected %}
                 id = "#" + "{{element_type}}" + "-" + {{selected}}
-                $(this).css("border-bottom","5px solid #f1c9ec");
+                $(this).css("border-bottom","3px solid #a6a6a6");
                 $('#existent-{{element_type}} > input').val({{selected}});
             {% endif %}
             $('.repository-item').click(function(){
@@ -18,7 +18,7 @@
                 
                 // reset background
                 $(this).parent().children().css('border-bottom', 'none')
-                $(this).css("border-bottom","5px solid #f1c9ec");
+                $(this).css("border-bottom","3px solid #a6a6a6");
 
                 if(sectionId == 'repo-marker'){
                     $('#existent-marker > input').val(elementId.split("-")[1]);

--- a/src/ARte/users/jinja2/users/components/repository-list.jinja2
+++ b/src/ARte/users/jinja2/users/components/repository-list.jinja2
@@ -9,7 +9,7 @@
         <script>
             {%if selected %}
                 id = "#" + "{{element_type}}" + "-" + {{selected}}
-                $(id).css('background-color', '#f1c9ec');
+                $(this).css("border-bottom","5px solid #f1c9ec");
                 $('#existent-{{element_type}} > input').val({{selected}});
             {% endif %}
             $('.repository-item').click(function(){
@@ -17,9 +17,9 @@
                 let sectionId = $(this).parent().attr('id');
                 
                 // reset background
-                $(this).parent().children().css('background-color', 'white')
-                $(this).css('background-color', '#f1c9ec');
-            
+                $(this).parent().children().css('border-bottom', 'none')
+                $(this).css("border-bottom","5px solid #f1c9ec");
+
                 if(sectionId == 'repo-marker'){
                     $('#existent-marker > input').val(elementId.split("-")[1]);
                 }else{


### PR DESCRIPTION
This is my solution to issue #262 when I diagnostic a background problem on artwork items selection.

The current behavior is:
Artwork:
![after_hard](https://user-images.githubusercontent.com/10819341/67612869-5923c580-f77d-11e9-9acf-dd283b476c23.png)

![after_car](https://user-images.githubusercontent.com/10819341/67612843-22e64600-f77d-11e9-9cd3-2b361018cf37.png)

Exibition:
![after_exibition](https://user-images.githubusercontent.com/10819341/67612873-5f19a680-f77d-11e9-9a88-c96ace141c38.png)

All tests passed. I hope you like this upgrade.