### PR TITLE
Add a confirmation pop-up before deleting an artwork, exhibition, object or marker

### DIFF
--- a/src/ARte/users/jinja2/users/components/item-list.jinja2
+++ b/src/ARte/users/jinja2/users/components/item-list.jinja2
@@ -10,7 +10,12 @@
             {% if element_type == "marker" or element_type == "object" %}
                 <img id="{{ element.id }}" class="trigger-modal" data-elem-type="{{element_type}}" src="{{ element.source.url }}" height="50" width="50">
                 {% if deletable == True and not element.in_use %}
-                    <a href="{{ url('delete-content') }}?content_type={{element_type}}&id={{ element.id }}" class="delete">{{ _("Delete")}}</a>
+                    {% if element_type == "marker" %}
+                        <a href="{{ url('delete-content') }}?content_type={{element_type}}&id={{ element.id }}" onclick="return confirm('Are you sure you want to delete this marker?')" class="delete">{{ _("Delete")}}</a>
+                    {% endif %}
+                    {% if element_type == "object" %}
+                        <a href="{{ url('delete-content') }}?content_type={{element_type}}&id={{ element.id }}" onclick="return confirm('Are you sure you want to delete this object?')" class="delete">{{ _("Delete")}}</a>
+                    {% endif %}
                 {% endif %}
             {% elif element_type == "artwork" %}
                 <div class="artwork-elements flex">
@@ -21,7 +26,7 @@
                         <a href="{{ url('edit-artwork') }}?id={{element.id}}" class="edit">edit</a>
                     {% endif %}
                     {% if deletable == True and not element.in_use %}
-                        <a href="{{ url('delete-content') }}?content_type={{element_type}}&id={{ element.id }}" class="delete">{{ _("Delete")}}</a>
+                        <a href="{{ url('delete-content') }}?content_type={{element_type}}&id={{ element.id }}" onclick="return confirm('Are you sure you want to delete this artwork?')" class="delete">{{ _("Delete")}}</a>
                     {% endif %}
                 </div>
             {% else %}
@@ -41,7 +46,7 @@
                     <a href="{{ url('edit-exhibit') }}?id={{element.id}}" class="edit">{{ _("Edit")}}</a>
                 {% endif %}
                 {% if deletable == True %}                
-                    <a href="{{ url('delete-content') }}?content_type={{element_type}}&id={{element.id}}" class="delete">{{ _("Delete")}}</a>
+                    <a href="{{ url('delete-content') }}?content_type={{element_type}}&id={{element.id}}" onclick="return confirm('Are you sure you want to delete this exhibition?')" class="delete">{{ _("Delete")}}</a>
                 {% endif %}
                 </div>
             {% endif %}


### PR DESCRIPTION
It resolves the issue #238, so that the user does not delete something accidentally.