### PR TITLE
Collection now shows 8 items per category

### DIFF
--- a/src/ARte/core/jinja2/core/collection.jinja2
+++ b/src/ARte/core/jinja2/core/collection.jinja2
@@ -8,29 +8,37 @@
 
             {# FIXME: maybe this can be improved #}
             <link rel="stylesheet" href="/static/css/repository-list.css">
-            <h1 class="titExb">{{_("Jandig Exhibitions")}}</h1>
+            
                 {% if exhibits %}
+                    <h1 class="titExb">{{_("Jandig Exhibitions")}}</h1>
                     {% with repository_list = exhibits, element_type="exhibit"%}
                         {% include "users/components/item-list.jinja2" %}
                     {% endwith %}
+                    <a href = "/see_all?which=exhibits">{{_("All Exhibits")}}</a>
                 {% endif %}
-            <h1 class="titArt">{{_("Jandig Artworks")}}</h1>
+            
                 {% if artworks %}
+                    <h1 class="titArt">{{_("Jandig Artworks")}}</h1>
                     {% with repository_list = artworks, element_type="artwork" %}
                         {% include "users/components/item-list.jinja2" %}
                     {% endwith %}
+                    <a href = "/see_all?which=artworks">{{_("All Artworks")}}</a>
                 {% endif %}
-            <h1 class="titMrk">{{_("Jandig Markers")}}</h1>
+            
                 {% if markers %}
+                    <h1 class="titMrk">{{_("Jandig Markers")}}</h1>
                     {% with repository_list = markers, element_type="marker"%}
                         {% include "users/components/item-list.jinja2" %}
                     {% endwith %}
+                    <a href = "/see_all?which=markers">{{_("All Markers")}}</a>
                 {% endif %}
-            <h1 class="titObj">{{_("Jandig Objects")}}</h1>
+            
                 {% if objects %}
+                    <h1 class="titObj">{{_("Jandig Objects")}}</h1>
                     {% with repository_list = objects, element_type="object" %}
                         {% include "users/components/item-list.jinja2" %}
                     {% endwith%}
+                    <a href = "/see_all?which=objects" >{{_("All Objects")}}</a>
                 {% endif %}
             {% include "users/components/elements-modal.jinja2" %}
         </div>

--- a/src/ARte/core/urls.py
+++ b/src/ARte/core/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path, re_path, include
-from .views import service_worker, index, upload_image, exhibit_select, collection, exhibit_detail
+from .views import see_all, service_worker, index, upload_image, exhibit_select, collection, exhibit_detail
 from .views_s.home import home, ar_viewer, community, marker_generator, documentation
 
 urlpatterns = [
@@ -13,4 +13,5 @@ urlpatterns = [
     path('sw.js', service_worker, name='sw'),
     path('upload', upload_image, name='upload-image'),
     path('i18n/', include('django.conf.urls.i18n')),
+    path('see_all/', see_all, name='see-all'),
 ]

--- a/src/ARte/core/views.py
+++ b/src/ARte/core/views.py
@@ -24,14 +24,62 @@ def index(request):
     return render(request, 'core/exhibit.jinja2', ctx)
 
 def collection(request):
+
+    exhibits = []
+    artworks = []
+    markers  = []
+    objects  = []
+
+    if Exhibit.objects.count() < 9: # 9 is the number for 8 items to show at most
+        x = Exhibit.objects.count()+1
+    else:
+        x = 9
+    if Artwork.objects.count() < 9:
+        y = Artwork.objects.count()+1
+    else:
+        y = 9
+    if Marker.objects.count() < 9:
+        z = Marker.objects.count()+1
+    else:
+        z = 9
+    if Object.objects.count() < 9:
+        w = Object.objects.count()+1
+    else:
+        w = 9
+
+    for i in range(1, x):
+        exhibits.append(Exhibit.objects.get(id = i))
+    for i in range(1, y):
+        artworks.append(Artwork.objects.get(id = i))
+    for i in range(1, z):
+        markers.append (Marker.objects.get(id = i))
+    for i in range(1, w):
+        objects.append (Object.objects.get(id = i))
+
     ctx = {
-        "artworks": Artwork.objects.all(),
-        "exhibits": Exhibit.objects.all(),
-        "markers": Marker.objects.all(),
-        "objects": Object.objects.all(),
+        "artworks": artworks,
+        "exhibits": exhibits,
+        "markers": markers,
+        "objects": objects,
     }
 
     return render(request, 'core/collection.jinja2', ctx)
+
+def see_all(request):
+    request_type = request.GET.get('which')
+    ctx = {}    
+    if   request_type == 'objects':
+        ctx = { 'objects' : Object.objects.all(), }
+    elif request_type == 'markers':
+        ctx = { 'markers ': Marker.objects.all(), } 
+    elif request_type == 'artworks':
+        ctx = { 'artworks': Artwork.objects.all(), }
+    elif request_type == 'exhibits':
+        ctx = { 'exhibits': Exhibit.objects.all(), }
+
+    return render(request, 'core/collection.jinja2', ctx)
+
+
 
 def upload_image(request):
     if request.method == 'POST':

--- a/src/ARte/core/views.py
+++ b/src/ARte/core/views.py
@@ -25,36 +25,10 @@ def index(request):
 
 def collection(request):
 
-    exhibits = []
-    artworks = []
-    markers  = []
-    objects  = []
-
-    if Exhibit.objects.count() < 9: # 9 is the number for 8 items to show at most
-        x = Exhibit.objects.count()+1
-    else:
-        x = 9
-    if Artwork.objects.count() < 9:
-        y = Artwork.objects.count()+1
-    else:
-        y = 9
-    if Marker.objects.count() < 9:
-        z = Marker.objects.count()+1
-    else:
-        z = 9
-    if Object.objects.count() < 9:
-        w = Object.objects.count()+1
-    else:
-        w = 9
-
-    for i in range(1, x):
-        exhibits.append(Exhibit.objects.get(id = i))
-    for i in range(1, y):
-        artworks.append(Artwork.objects.get(id = i))
-    for i in range(1, z):
-        markers.append (Marker.objects.get(id = i))
-    for i in range(1, w):
-        objects.append (Object.objects.get(id = i))
+    exhibits = Exhibit.objects.all().order_by('-id')[:4]
+    artworks = Artwork.objects.all().order_by('-id')[:8]
+    markers  = Marker.objects.all().order_by('-id')[:8]
+    objects  = Object.objects.all().order_by('-id')[:8]
 
     ctx = {
         "artworks": artworks,


### PR DESCRIPTION
The collection page now shows only 8 items per category (exhibit, artwork, marker and object) and has a link to a page with all the content in a category