### PR TITLE
Create button to redirect marker generator #327 

### DIFF
--- a/src/ARte/users/jinja2/users/upload.jinja2
+++ b/src/ARte/users/jinja2/users/upload.jinja2
@@ -29,8 +29,8 @@
                         <h3>{{_("Choose Object")}}</h3>
                     {% else %}
                         <blockquote>
-                            No Marker files yet? Don't fret! You can get them 
-                            <a href="{{ url('marker-generator') }}" target="_blank" class="useful">here</a>.
+                            No Marker files yet? Don't fret! You can get them here
+                            <button type="button" onclick="window.open('/generator', '_blank')">MARKER GENERATOR</button>
                         </blockquote>
                         <p class="title-field"  id="title-field">
                             <h3>{{_("Choose Marker's title")}}


### PR DESCRIPTION
## Description

Create button that when clicked opens the page https://jandig.app/generator/.

## Resolves (Issues)

#327 

## General tasks performed
* Remove the link on the "here" word from the phase "No Marker files yet? Don't fret! You can get them here."
* Insert button with link.

@devsalula helped with this issue.
### Have you confirmed the application builds locally without error? See [here](https://github.com/memeLab/Jandig#running).

- [x] Yes
- [ ] No

