### PR TITLE
[REVIEW] 318 - slug input for exhibition url

### DIFF
--- a/src/ARte/users/forms.py
+++ b/src/ARte/users/forms.py
@@ -239,8 +239,8 @@ class ExhibitForm(forms.Form):
 
     def clean_slug(self):
         data = self.cleaned_data['slug']
-        # if not re.match("^[a-zA-Z0-9_]*$", data):
-            # raise forms.ValidationError(_("Slug can't contain spaces or special characters"))
+        if not re.match("^[a-zA-Z0-9_]*$", data):
+            raise forms.ValidationError(_("Slug can't contain spaces or special characters"))
         return data
 
     def __init__(self, *args, **kwargs):

--- a/src/ARte/users/forms.py
+++ b/src/ARte/users/forms.py
@@ -237,14 +237,14 @@ class ExhibitForm(forms.Form):
     # FIXME: maybe this can be improved. Possible bug on max artworks per exhibit 
     artworks = forms.CharField(max_length=1000)
 
-    # def clean_slug(self):
-    #     data = self.cleaned_data['slug']
-    #     if not re.match("^[a-zA-Z0-9_]*$", data):
-    #         raise forms.ValidationError(_("Url can't contain spaces or special characters"))
-    #     return data
+    def clean_slug(self):
+        data = self.cleaned_data['slug']
+        if not re.match("^[a-zA-Z0-9_]*$", data):
+            raise forms.ValidationError(_("Url can't contain spaces or special characters"))
+        return data
 
     def __init__(self, *args, **kwargs):
         super(ExhibitForm, self).__init__(*args, **kwargs)
 
         self.fields['name'].widget.attrs['placeholder'] = _('Exhibit Title')
-        self.fields['slug'].widget.attrs['placeholder'] = _('Exhibit URL')
+        self.fields['slug'].widget.attrs['placeholder'] = _('Complete with your Exhibit URL here')

--- a/src/ARte/users/forms.py
+++ b/src/ARte/users/forms.py
@@ -237,11 +237,11 @@ class ExhibitForm(forms.Form):
     # FIXME: maybe this can be improved. Possible bug on max artworks per exhibit 
     artworks = forms.CharField(max_length=1000)
 
-    def clean_slug(self):
-        data = self.cleaned_data['slug']
-        if not re.match("^[a-zA-Z0-9_]*$", data):
-            raise forms.ValidationError(_("Slug can't contain spaces or special characters"))
-        return data
+    # def clean_slug(self):
+    #     data = self.cleaned_data['slug']
+    #     if not re.match("^[a-zA-Z0-9_]*$", data):
+    #         raise forms.ValidationError(_("Url can't contain spaces or special characters"))
+    #     return data
 
     def __init__(self, *args, **kwargs):
         super(ExhibitForm, self).__init__(*args, **kwargs)

--- a/src/ARte/users/jinja2/users/exhibit-create.jinja2
+++ b/src/ARte/users/jinja2/users/exhibit-create.jinja2
@@ -43,7 +43,7 @@
                         {{ form.visible_fields()[1] }}
                         {{ form.visible_fields()[1].errors }}
                     </p>
-                    <input class="select-btn next-btn" type="submit" value="{{ _('Publish Exhibit') }}"/>
+                    <input class="select-btn next-btn" onclick="qualquerCoisa()" type="submit" value="{{ _('Publish Exhibit') }}"/>
                 </div>
             </form>
         </div>
@@ -71,6 +71,16 @@
                     $('#next-info').prop('disabled', true);
                 }
             }
+
+
+            function qualquerCoisa() {
+                var slug = document.getElementById('id_slug').value
+                let validate = /^[a-zA-Z0-9_]*$/
+                if(!slug.match(validate)) {
+                    alert("Slug can't contain spaces or special characters")
+                }
+            }
+
             setInterval(activateNextButton, 100);
             // modal events
             $('#select-artworks').click(function(){

--- a/src/ARte/users/jinja2/users/exhibit-create.jinja2
+++ b/src/ARte/users/jinja2/users/exhibit-create.jinja2
@@ -36,13 +36,14 @@
                 <div id="artwork-modal" class="tab">
                     <h4 class="modal-title">{{ _('Exhibit Information (2/2)') }}</h4>
                       <p class="upload-field" id="info-name-field">
-                        {{ form.visible_fields()[0] }}
-                        {{ form.visible_fields()[0].errors }}
+                          {{ form.visible_fields()[0] }}
+                          {{ form.visible_fields()[0].errors }}
                       </p>
-                    <p class="upload-field" id="info-slug-field">
-                        {{ form.visible_fields()[1] }}
-                        {{ form.visible_fields()[1].errors }}
-                    </p>
+                      <label style="float: left; width: 35%; display: flex; padding-top: 3%">https://jandig.app/</label>
+                        <p style="float: right; width: 65%">
+                            {{ form.visible_fields()[1] }}
+                            {{ form.visible_fields()[1].errors }} 
+                        </p>
                     <input class="select-btn next-btn" onclick="cleanSlug()" type="submit" value="{{ _('Publish Exhibit') }}"/>
                 </div>
             </form>

--- a/src/ARte/users/jinja2/users/exhibit-create.jinja2
+++ b/src/ARte/users/jinja2/users/exhibit-create.jinja2
@@ -5,6 +5,7 @@
     <section class="create-exhibit">
         {# FIXME: maybe this can be improved #}
         <link rel="stylesheet" href="/static/css/marker-creation.css">
+        <link rel="stylesheet" href="/static/css/label.css">
         <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-modal/0.9.1/jquery.modal.min.js"></script>
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jquery-modal/0.9.1/jquery.modal.min.css" />
         <div class="container">
@@ -39,7 +40,8 @@
                           {{ form.visible_fields()[0] }}
                           {{ form.visible_fields()[0].errors }}
                       </p>
-                      <label style="float: left; width: 35%; display: flex; padding-top: 3%">https://jandig.app/</label>
+                    <p class="gallery-title">{{ _('Your exhibit URL will look like this') }}</p>
+                      <label class="url-helper">https://jandig.app/</label>
                         <p style="float: right; width: 65%">
                             {{ form.visible_fields()[1] }}
                             {{ form.visible_fields()[1].errors }} 

--- a/src/ARte/users/jinja2/users/exhibit-create.jinja2
+++ b/src/ARte/users/jinja2/users/exhibit-create.jinja2
@@ -43,7 +43,7 @@
                         {{ form.visible_fields()[1] }}
                         {{ form.visible_fields()[1].errors }}
                     </p>
-                    <input class="select-btn next-btn" onclick="qualquerCoisa()" type="submit" value="{{ _('Publish Exhibit') }}"/>
+                    <input class="select-btn next-btn" onclick="cleanSlug()" type="submit" value="{{ _('Publish Exhibit') }}"/>
                 </div>
             </form>
         </div>
@@ -73,12 +73,15 @@
             }
 
 
-            function qualquerCoisa() {
+            function cleanSlug() {
                 var slug = document.getElementById('id_slug').value
                 let validate = /^[a-zA-Z0-9_]*$/
                 if(!slug.match(validate)) {
-                    alert("Slug can't contain spaces or special characters")
+                    $('input[type="submit"]').prop('disabled', true);
+                    alert("Url " + slug + " can't contain spaces or special characters (i.e: :, /)");
+                    
                 }
+                location.reload();
             }
 
             setInterval(activateNextButton, 100);

--- a/src/ARte/users/static/css/label.css
+++ b/src/ARte/users/static/css/label.css
@@ -1,0 +1,33 @@
+.url-helper {
+    float: left; 
+    width: 35%; 
+    font-weight: bold;
+}
+
+@media screen and (min-width: 601px) {
+    label.url-helper {
+      font-size: 15px;
+      padding-top: 3%;
+    }
+  }
+  
+  @media screen and (max-width: 600px) {
+    label.url-helper {
+      font-size: 12px;
+      padding-top: 3.2%;
+    }
+  }
+
+  @media screen and (max-width: 371px) {
+    label.url-helper {
+      font-size: 10px;
+      padding-top: 5%;
+    }
+  }
+
+  @media screen and (max-width: 320px) {
+    label.url-helper {
+      font-size: 9px;
+      padding-top: 6%;
+    }
+  }


### PR DESCRIPTION
## Description

In this Pull Request, logic has been added so that users will receive an error message when they try to input an exhibit URL with special characters, as well as not allowing said exhibit to be registered in the database.

## Resolves (Issues)

#318 

## General tasks performed
* Filtered the input to accept only non-special characters
* Added a visual alert so the user will see when the slug is invalid.

@devsalula helped me with this issue.

### Have you confirmed the application builds locally without error? See [here](https://github.com/memeLab/Jandig#running).

- [x] Yes
- [ ] No