### PR TITLE
[REVIEW] 242-Wrong link to download Object

### DIFF
--- a/src/ARte/users/jinja2/users/components/elements-modal.jinja2
+++ b/src/ARte/users/jinja2/users/components/elements-modal.jinja2
@@ -121,6 +121,7 @@
                         elementAuthor(data['author']);
                         usedInExhibit(data['id_marker'], data['id_object'], data['exhibits'], data['marker'], data['augmented'], element_id);
                         replaceButtons(data['title'], data['description']);
+                        downloadElement(data['type'], data['augmented_size']/1000, data['augmented']);
                     }
                 });
             }

--- a/src/ARte/users/views.py
+++ b/src/ARte/users/views.py
@@ -334,6 +334,7 @@ def element_get(request):
             'created_at': element.created_at.strftime('%d %b, %Y'),
             'marker': element.marker.source.url,
             'augmented': element.augmented.source.url,
+            'augmented_size': element.augmented.source.size,
             'title': element.title,
             'description': element.description,
         }


### PR DESCRIPTION
## Description

The modal doesn't display the correct object download link

 
## Resolves (Issues)

Issues  242 

## General tasks performed
* Get image path in downloadElement method

 
@devsalula helped me with this issue.
### Have you confirmed the application builds locally without error? See [here](https://github.com/memeLab/Jandig#running).

 

-[X] Yes
-[ ]No