### PR TITLE
[REVIEW] Adding marker transparency info to generator

### DIFF
--- a/src/ARte/core/jinja2/core/generator.html
+++ b/src/ARte/core/jinja2/core/generator.html
@@ -50,6 +50,10 @@
             <div class='tip' for='buttonUpload'>
                 Browse to the file you want to put inside the marker.
             </div>
+            <br/>
+            <div class='tip' for='buttonUpload'>
+                The marker generator does not support images with a transparent background. Take care to select an image that has a non-transparent background.
+            </div>
         </div>
 
         <div id='imageContainer'></div>


### PR DESCRIPTION
Co-authored-by: Saleh Kader <saleh.nazih.dev@gmail.com>

## Description

Adding a marker transparency alert on the generator screen..

## Resolves (Issues)

#278 

## General tasks performed
* Add marker transparency alert


### Have you confirmed the application builds locally without error? See [here](https://github.com/memeLab/Jandig#running).

- [X] Yes
- [ ] No