### PR TITLE
[REVIEW] - Block the editing of an object and artwork when in use

### DIFF
--- a/src/ARte/users/jinja2/users/components/item-list.jinja2
+++ b/src/ARte/users/jinja2/users/components/item-list.jinja2
@@ -21,7 +21,7 @@
                 {% if deletable == True and not element.in_use %}
                     <a href="{{ url('delete-content') }}?content_type={{element_type}}&id={{ element.id }}" onclick="return confirm('Are you sure you want to delete this object?')" class="delete">{{ _("Delete")}}</a>    
                 {% endif %}
-                {% if editable == True %}
+                {% if editable == True and not element.in_use %}
                     <a href="{{ url('edit-object') }}?id={{element.id}}" class="edit">edit</a>                
                 {% endif %}
             {% elif element_type == "artwork" %}
@@ -45,7 +45,7 @@
                             <img id="{{ element.id }}" class="trigger-modal" data-elem-type="{{element_type}}" src="{{ element.augmented.source.url }}" height="{{ element.augmented.yproportion * 50 }}" width="{{ element.augmented.xproportion * 50 }}">
                         {% endif %}
                     {% endif %}
-                    {% if editable == True %}
+                    {% if editable == True and not element.in_use %}
                         <a href="{{ url('edit-artwork') }}?id={{element.id}}" class="edit">edit</a>
                     {% endif %}
                     {% if deletable == True and not element.in_use %}


### PR DESCRIPTION
## Description

Blocks the editing of objects and artworks there are being used.

## Resolves (Issues)
#351 

## General tasks performed
* Adjust if clauses to check if the object or artwork is in use, if in use it cannot be edited.

### Have you confirmed the application builds locally without error? See [here](https://github.com/memeLab/Jandig#running).

- [x] Yes
- [ ] No

@shayanealcantara helped with this issue.