### PR TITLE
[WIP] Separate delete content into delete_content and delete_content_Moderator

### DIFF
--- a/src/ARte/users/views.py
+++ b/src/ARte/users/views.py
@@ -590,20 +590,25 @@ def delete_content(model, user, instance_id):
         
 
 def delete_content_Moderator(instance,user):
+    
     isInstanceSameTypeofModel = isinstance(instance, model)
+    isObject = isinstance(instance, Object)
+    isMarker = isinstance(instance, Marker)
+    isArtwork = isinstance(instance, Artwork)
+
 
     if isInstanceSameTypeofModel or not instance.in_use:
         instance.delete()
     elif instance.in_use:
-                if isinstance(instance, Object):
+                if isObject:
                     artworkIn = Artwork.objects.filter(augmented=instance)
                     artworkIn.delete()
                     instance.delete()
-                elif isinstance(instance, Marker):
+                elif isMarker:
                     artworkIn = Artwork.objects.filter(marker=instance)
                     artworkIn.delete()
                     instance.delete()
-                elif isinstance(instance, Artwork):
+                elif isArtwork:
                     instance.delete()
 
 

--- a/src/ARte/users/views.py
+++ b/src/ARte/users/views.py
@@ -600,16 +600,16 @@ def delete_content_Moderator(instance,user):
     if isInstanceSameTypeofModel or not instance.in_use:
         instance.delete()
     elif instance.in_use:
-                if isObject:
-                    artworkIn = Artwork.objects.filter(augmented=instance)
-                    artworkIn.delete()
-                    instance.delete()
-                elif isMarker:
-                    artworkIn = Artwork.objects.filter(marker=instance)
-                    artworkIn.delete()
-                    instance.delete()
-                elif isArtwork:
-                    instance.delete()
+        if isObject:
+            artworkIn = Artwork.objects.filter(augmented=instance)
+            artworkIn.delete()
+            instance.delete()
+        elif isMarker:
+            artworkIn = Artwork.objects.filter(marker=instance)
+            artworkIn.delete()
+            instance.delete()
+        elif isArtwork:
+            instance.delete()
 
 
 def related_content(request):


### PR DESCRIPTION
## Description

Divide  delete_content function into delete_content and  delete_content_Moderator to separate the deletion of a normal user and a moderator;

## Resolves Parcially (Issues)
#360 

## General tasks performed
- [x] Divide the delete_content function 
- [x] Create function delete_content_Moderator

### Have you confirmed the application builds locally without error? See [here](https://github.com/memeLab/Jandig#running).

- [x] Yes
- [ ] No


## Images
### Before
![Ivan_BeforeSolid_deleteContent](https://user-images.githubusercontent.com/42387797/100386247-9a7f4800-3003-11eb-867c-9463b911da26.png)
### After
![Ivan_AfterSolid_deletContent](https://user-images.githubusercontent.com/42387797/100386258-a1a65600-3003-11eb-9c04-a0b98727c221.png)




## Observation
I did not know how to test moderator permissions, so before accepting this pull request it is necessary to test if the moderator delete still works. I would appreciate if someone told me how to test as moderator.