### PR TITLE
[REVIEW] 249 Simplify Marker Upload

### DIFF
--- a/src/ARte/users/forms.py
+++ b/src/ARte/users/forms.py
@@ -176,14 +176,12 @@ class UploadMarkerForm(forms.ModelForm):
         super(UploadMarkerForm, self).__init__(*args, **kwargs)
 
         log.warning(self.fields)
-        self.fields['source'].widget.attrs['placeholder'] = _('browse file')
-        self.fields['source'].widget.attrs['accept'] = 'image/png, image/jpg'
         self.fields['author'].widget.attrs['placeholder'] = _('declare different author name')
         self.fields['title'].widget.attrs['placeholder'] = _("Marker's title")
 
     class Meta:
         model = Marker
-        exclude = ('owner', 'uploaded_at', 'patt')
+        exclude = ('owner', 'uploaded_at', 'patt', 'source')
 
 class UploadObjectForm(forms.ModelForm):
     

--- a/src/ARte/users/forms.py
+++ b/src/ARte/users/forms.py
@@ -187,8 +187,6 @@ class UploadMarkerForm(forms.ModelForm):
         model = Marker
         exclude = ('owner', 'uploaded_at')
 
-
-
 class UploadObjectForm(forms.ModelForm):
     
     def __init__(self, *args, **kwargs):

--- a/src/ARte/users/forms.py
+++ b/src/ARte/users/forms.py
@@ -178,14 +178,12 @@ class UploadMarkerForm(forms.ModelForm):
         log.warning(self.fields)
         self.fields['source'].widget.attrs['placeholder'] = _('browse file')
         self.fields['source'].widget.attrs['accept'] = 'image/png, image/jpg'
-        self.fields['patt'].widget.attrs['placeholder'] = _('browse file')
-        self.fields['patt'].widget.attrs['accept'] = '.patt'
         self.fields['author'].widget.attrs['placeholder'] = _('declare different author name')
         self.fields['title'].widget.attrs['placeholder'] = _("Marker's title")
 
     class Meta:
         model = Marker
-        exclude = ('owner', 'uploaded_at')
+        exclude = ('owner', 'uploaded_at', 'patt')
 
 class UploadObjectForm(forms.ModelForm):
     

--- a/src/ARte/users/forms.py
+++ b/src/ARte/users/forms.py
@@ -176,12 +176,14 @@ class UploadMarkerForm(forms.ModelForm):
         super(UploadMarkerForm, self).__init__(*args, **kwargs)
 
         log.warning(self.fields)
+        self.fields['source'].widget.attrs['placeholder'] = _('browse file')
+        self.fields['source'].widget.attrs['accept'] = 'image/png, image/jpg'
         self.fields['author'].widget.attrs['placeholder'] = _('declare different author name')
         self.fields['title'].widget.attrs['placeholder'] = _("Marker's title")
 
     class Meta:
         model = Marker
-        exclude = ('owner', 'uploaded_at', 'patt', 'source')
+        exclude = ('owner', 'uploaded_at', 'patt')
 
 class UploadObjectForm(forms.ModelForm):
     

--- a/src/ARte/users/jinja2/users/upload-marker.jinja2
+++ b/src/ARte/users/jinja2/users/upload-marker.jinja2
@@ -17,12 +17,11 @@
                     <p class="upload-field" id="source-field">
                         <p class="title-field"  id="title-field">
                             <h3>{{_("Choose Marker's title")}}
-                            {{ form.visible_fields()[2] }}
-                            {{ form.visible_fields()[2].errors }}
+                            {{ form.visible_fields()[1] }}
+                            {{ form.visible_fields()[1].errors }}
                         </p>     
                         <h3>{{ _("Choose Marker image") }}</h3>
-                        {{ form.visible_fields()[0] }}
-                        {{ form.visible_fields()[0].errors }}
+                        <input type="file" id="marker" name="marker" accept="image/png, image/jpg">
                     </p>
 
                     <div id="imageContainer"></div>
@@ -36,8 +35,8 @@
                         
                     </p>
                     <p class="upload-field" id="author-field">
-                        {{ form.visible_fields()[1] }}
-                        {{ form.visible_fields()[1].errors }}
+                        {{ form.visible_fields()[0] }}
+                        {{ form.visible_fields()[0].errors }}
                     </p>
                     <div class="form-options">
                         <p>
@@ -74,7 +73,7 @@
             var innerImageURL = null;
             var fullMarkerURL = null;
 
-            $("#id_source").change(
+            $("#marker").change(
                 function(e) {
                     var file = e.originalEvent.srcElement.files[0];
                     var reader = new FileReader();

--- a/src/ARte/users/jinja2/users/upload-marker.jinja2
+++ b/src/ARte/users/jinja2/users/upload-marker.jinja2
@@ -5,6 +5,7 @@
     <section class="upload container">
         {# FIXME: maybe this can be improved #}
         <link rel="stylesheet" href="/static/css/upload.css">
+        <script src="/static/js/threex-arpatternfile.js"></script>
 
         {% if form_type == 'marker' and edit == False %}
             <h2>{{ _('Upload Marker') }}</h2>
@@ -27,7 +28,6 @@
                     <div id="imageContainer"></div>
 
                     {% if form_type == 'marker' %}
-                        <h3>{{ _('Choose .patt file') }}</h3>
                         <div class="upload-field" id="patt-field">
                             {{ form.visible_fields()[3] }}
                             {{ form.visible_fields()[3].errors }}
@@ -77,22 +77,36 @@
                 }
             });
 
+            var innerImageURL = null;
+            var fullMarkerURL = null;
+
             $("#id_source").change(
                 function(e) {
                     var file = e.originalEvent.srcElement.files[0];
-                    var marker_preview = document.createElement("img");
-
-                    previewAndLoadFile = function() {
-                        marker_preview.src = reader.result;
-                        marker_preview.id = "img-preview";
-                        document.getElementById("imageContainer").appendChild(marker_preview); //make preview image of the object/marker show
-                    }
-
                     var reader = new FileReader();
-                    reader.onloadend = previewAndLoadFile;
+                    reader.onload = function(event) {
+                        innerImageURL = event.target.result;
+                        uploadFullMarkerImage(e);
+                    };
                     reader.readAsDataURL(file);
                 }
             );
+
+            function uploadFullMarkerImage(e) {
+                var patternRatio = 0.6;
+
+                THREEx.ArPatternFile.buildFullMarker(innerImageURL, patternRatio, function onComplete(markerUrl) {
+                    fullMarkerURL = markerUrl
+
+                    var fullMarkerImage = document.createElement('img')
+                    fullMarkerImage.src = fullMarkerURL
+
+                    // put fullMarkerImage into #imageContainer
+                    var container = document.querySelector('#imageContainer')
+                    while (container.firstChild) container.removeChild(container.firstChild);
+                    container.appendChild(fullMarkerImage)                    
+                })
+            }
         </script>
     </section>
 {% endblock %}

--- a/src/ARte/users/jinja2/users/upload-marker.jinja2
+++ b/src/ARte/users/jinja2/users/upload-marker.jinja2
@@ -27,12 +27,6 @@
 
                     <div id="imageContainer"></div>
 
-                    {% if form_type == 'marker' %}
-                        <div class="upload-field" id="patt-field">
-                            {{ form.visible_fields()[3] }}
-                            {{ form.visible_fields()[3].errors }}
-                        </div>
-                    {% endif %}
                     <p class="form-options">
 
                         <input id="author-chk" type="checkbox" name="author" value="1">

--- a/src/ARte/users/jinja2/users/upload-marker.jinja2
+++ b/src/ARte/users/jinja2/users/upload-marker.jinja2
@@ -14,10 +14,6 @@
                 <form name="upload-form" method="post" enctype="multipart/form-data">
                     {{ csrf_input }}
                     <p class="upload-field" id="source-field">
-                        <blockquote>
-                            No Marker files yet? Don't fret! You can get them here
-                            <button type="button" onclick="window.open('/generator', '_blank')">MARKER GENERATOR</button>
-                        </blockquote>
                         <p class="title-field"  id="title-field">
                             <h3>{{_("Choose Marker's title")}}
                             {{ form.visible_fields()[2] }}
@@ -27,6 +23,8 @@
                         {{ form.visible_fields()[0] }}
                         {{ form.visible_fields()[0].errors }}
                     </p>
+
+                    <div id="imageContainer"></div>
 
                     {% if form_type == 'marker' %}
                         <h3>{{ _('Choose .patt file') }}</h3>
@@ -77,7 +75,24 @@
                     $('#author-field > input').prop('readonly', false);
                     $('#author-field > input').val("");
                 }
-            });                            
+            });
+
+            $("#id_source").change(
+                function(e) {
+                    var file = e.originalEvent.srcElement.files[0];
+                    var marker_preview = document.createElement("img");
+
+                    previewAndLoadFile = function() {
+                        marker_preview.src = reader.result;
+                        marker_preview.id = "img-preview";
+                        document.getElementById("imageContainer").appendChild(marker_preview); //make preview image of the object/marker show
+                    }
+
+                    var reader = new FileReader();
+                    reader.onloadend = previewAndLoadFile;
+                    reader.readAsDataURL(file);
+                }
+            );
         </script>
     </section>
 {% endblock %}

--- a/src/ARte/users/jinja2/users/upload-marker.jinja2
+++ b/src/ARte/users/jinja2/users/upload-marker.jinja2
@@ -1,0 +1,83 @@
+
+{% extends '/core/home.jinja2' %}
+
+{% block content %}
+    <section class="upload container">
+        {# FIXME: maybe this can be improved #}
+        <link rel="stylesheet" href="/static/css/upload.css">
+
+        {% if form_type == 'marker' and edit == False %}
+            <h2>{{ _('Upload Marker') }}</h2>
+        {% endif %}
+        <section class="upload-form">
+            <div class="container">
+                <form name="upload-form" method="post" enctype="multipart/form-data">
+                    {{ csrf_input }}
+                    <p class="upload-field" id="source-field">
+                        <blockquote>
+                            No Marker files yet? Don't fret! You can get them here
+                            <button type="button" onclick="window.open('/generator', '_blank')">MARKER GENERATOR</button>
+                        </blockquote>
+                        <p class="title-field"  id="title-field">
+                            <h3>{{_("Choose Marker's title")}}
+                            {{ form.visible_fields()[2] }}
+                            {{ form.visible_fields()[2].errors }}
+                        </p>     
+                        <h3>{{ _("Choose Marker image") }}</h3>
+                        {{ form.visible_fields()[0] }}
+                        {{ form.visible_fields()[0].errors }}
+                    </p>
+
+                    {% if form_type == 'marker' %}
+                        <h3>{{ _('Choose .patt file') }}</h3>
+                        <div class="upload-field" id="patt-field">
+                            {{ form.visible_fields()[3] }}
+                            {{ form.visible_fields()[3].errors }}
+                        </div>
+                    {% endif %}
+                    <p class="form-options">
+
+                        <input id="author-chk" type="checkbox" name="author" value="1">
+                        {% if form_type == 'marker' %}
+                            {{ _("I'm this Marker author") }}
+                        {% endif %}
+                        
+                    </p>
+                    <p class="upload-field" id="author-field">
+                        {{ form.visible_fields()[1] }}
+                        {{ form.visible_fields()[1].errors }}
+                    </p>
+                    <div class="form-options">
+                        <p>
+                            <input id="agreement-chk" type="checkbox" name="agreement" value="1">
+                            {{ _('I agree to have this content under <a target="_blank" href="https://creativecommons.org/licenses/by-sa/4.0/legalcode">CC BY-SA 4.0</a> and I\'m aware that it can\'t be removed after other people are using it.') }}
+                        </p>
+                    </div> 
+                    <input class="submit-btn" type="submit" value="{{ _('Submit') }}" disabled="disabled"/>
+                </form>
+            </div>
+        </section>
+
+        <script>
+            $('#agreement-chk').click(function(){
+                if($(this).prop('checked') == true){
+                    $('input[type="submit"]').prop('disabled', false);
+                }else{
+                    $('input[type="submit"]').prop('disabled', true);
+                }
+            });
+
+            $('#author-chk').click(function(){
+                if($(this).prop('checked') == true){
+                    let user = $('div.welcome > p > a')[0].innerText;
+                    console.log(user);
+                    $('#author-field > input').val(user);
+                    $('#author-field > input').prop('readonly', true);
+                }else{
+                    $('#author-field > input').prop('readonly', false);
+                    $('#author-field > input').val("");
+                }
+            });                            
+        </script>
+    </section>
+{% endblock %}

--- a/src/ARte/users/jinja2/users/upload-marker.jinja2
+++ b/src/ARte/users/jinja2/users/upload-marker.jinja2
@@ -17,11 +17,12 @@
                     <p class="upload-field" id="source-field">
                         <p class="title-field"  id="title-field">
                             <h3>{{_("Choose Marker's title")}}
-                            {{ form.visible_fields()[1] }}
-                            {{ form.visible_fields()[1].errors }}
+                            {{ form.visible_fields()[2] }}
+                            {{ form.visible_fields()[2].errors }}
                         </p>     
                         <h3>{{ _("Choose Marker image") }}</h3>
-                        <input type="file" id="marker" name="marker" accept="image/png, image/jpg">
+                            {{ form.visible_fields()[0] }}
+                            {{ form.visible_fields()[0].errors }}
                     </p>
 
                     <div id="imageContainer"></div>
@@ -35,8 +36,8 @@
                         
                     </p>
                     <p class="upload-field" id="author-field">
-                        {{ form.visible_fields()[0] }}
-                        {{ form.visible_fields()[0].errors }}
+                        {{ form.visible_fields()[1] }}
+                        {{ form.visible_fields()[1].errors }}
                     </p>
                     <div class="form-options">
                         <p>
@@ -73,7 +74,7 @@
             var innerImageURL = null;
             var fullMarkerURL = null;
 
-            $("#marker").change(
+            $("#id_source").change(
                 function(e) {
                     var file = e.originalEvent.srcElement.files[0];
                     var reader = new FileReader();

--- a/src/ARte/users/jinja2/users/upload-object.jinja2
+++ b/src/ARte/users/jinja2/users/upload-object.jinja2
@@ -6,9 +6,7 @@
         {# FIXME: maybe this can be improved #}
         <link rel="stylesheet" href="/static/css/upload.css">
 
-        {% if form_type == 'marker' and edit == False %}
-            <h2>{{ _('Upload Marker') }}</h2>
-        {% elif form_type == 'object' and edit == False %}
+        {% if form_type == 'object' and edit == False %}
             <h2>{{ _('Upload Object') }}</h2>
         {% else %}
             <h2>{{_('Edit_object')}}</h2>
@@ -27,17 +25,6 @@
                     <p class="upload-field" id="source-field">
                     {%if route == 'object-upload' %}
                         <h3>{{_("Choose Object")}}</h3>
-                    {% else %}
-                        <blockquote>
-                            No Marker files yet? Don't fret! You can get them here
-                            <button type="button" onclick="window.open('/generator', '_blank')">MARKER GENERATOR</button>
-                        </blockquote>
-                        <p class="title-field"  id="title-field">
-                            <h3>{{_("Choose Marker's title")}}
-                            {{ form.visible_fields()[2] }}
-                            {{ form.visible_fields()[2].errors }}
-                        </p>     
-                        <h3>{{ _("Choose Marker image") }}</h3>
                     {% endif %}
                         {{ form.visible_fields()[0] }}
                         {{ form.visible_fields()[0].errors }}
@@ -73,19 +60,10 @@
 
                     </div>
                     {% endif %}
-                    {% if form_type == 'marker' %}
-                        <h3>{{ _('Choose .patt file') }}</h3>
-                        <div class="upload-field" id="patt-field">
-                            {{ form.visible_fields()[3] }}
-                            {{ form.visible_fields()[3].errors }}
-                        </div>
-                    {% endif %}
                     <p class="form-options">
 
                         <input id="author-chk" type="checkbox" name="author" value="1">
-                        {% if form_type == 'marker' %}
-                            {{ _("I'm this Marker author") }}
-                        {% elif form_type == 'object' %}
+                        {% if form_type == 'object' %}
                             {{ _("I'm this Object author") }}
                         {% endif %}
                         

--- a/src/ARte/users/models.py
+++ b/src/ARte/users/models.py
@@ -47,11 +47,12 @@ class Marker(models.Model):
         return self.source.name
 
     def save(self, *args, **kwargs):
-        fs = FileSystemStorage()
-        fileimage = fs.save(self.source.name, self.source)
-        fileurl = fs.url(fileimage)
+        filestorage = FileSystemStorage()
+        fileimage = filestorage.save(self.source.name, self.source)
+        fileurl = filestorage.url(fileimage)
         path = 'src/ARte/users' + fileurl
         self.source = create_marker(path)
+        self.patt = create_patt(path)
         super().save(*args, **kwargs)
 
     @property
@@ -78,10 +79,18 @@ class Marker(models.Model):
             return True
         return False
 
+
+def create_patt(path):
+    generate_patt(path)
+    sliced = path.split('.')
+    patt_path = sliced[0] + '.patt'
+    return patt_path
+
+
 def create_marker(path):
     generate_marker(path)
     sliced = path.split('.')
-    marker_path = sliced[0] + '_marker.' + sliced[1]
+    marker_path = sliced[0] + '_marker.png'
     output = BytesIO()
     marker_pil = Image.open(marker_path)
     marker_pil.save(output, format='PNG', quality=100)

--- a/src/ARte/users/static/css/upload.css
+++ b/src/ARte/users/static/css/upload.css
@@ -63,6 +63,19 @@ video{
     max-height: 100%;
 }
 
+div#imageContainer {
+    max-width: 320px;
+    height: 320px;
+    margin: 25px auto;
+    background: url(../images/icons/icoEptG.png) no-repeat center center;
+    background-size: cover;
+}
+
+div#imageContainer img {
+    max-width: 100%;
+    height: auto;
+}
+
 @media only screen and (max-width: 600px){
     #content-box {
         height: 60%;

--- a/src/ARte/users/views.py
+++ b/src/ARte/users/views.py
@@ -371,7 +371,12 @@ def upload_view(request, form_class, form_type, route):
             return redirect('home')
     else:
         form = form_class()
-    return render(request,'users/upload.jinja2',
+
+    if form_type == 'marker':
+        return render(request,'users/upload-marker.jinja2',
+        {'form_type': form_type, 'form': form, 'route': route, 'edit': False})
+
+    return render(request,'users/upload-object.jinja2',
         {'form_type': form_type, 'form': form, 'route': route, 'edit': False})
 
 

--- a/src/ARte/users/views.py
+++ b/src/ARte/users/views.py
@@ -4,7 +4,6 @@ from datetime import datetime
 import hashlib
 import smtplib
 import time
-from pymarker.core import generate_marker, generate_patt
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 log = logging.getLogger('ej')
@@ -367,8 +366,7 @@ def object_upload(request):
 
 def upload_view(request, form_class, form_type, route):
     if request.method == 'POST':
-        create_marker(request.FILES['marker'])
-        form = form_class(request.POST)
+        form = form_class(request.POST, request.FILES)
         if form.is_valid():
             upload = form.save(commit=False)
             upload.owner = request.user.profile
@@ -383,14 +381,6 @@ def upload_view(request, form_class, form_type, route):
 
     return render(request,'users/upload-object.jinja2',
         {'form_type': form_type, 'form': form, 'route': route, 'edit': False})
-
-def create_marker(file):
-    fs = FileSystemStorage()
-    fileimage = fs.save(file.name, file)
-    fileurl = fs.url(fileimage)
-    path = 'src/ARte/users' + fileurl
-    generate_marker(path)
-    generate_patt(path)
 
 @login_required
 def edit_object(request):

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -12,3 +12,4 @@ django-docs ~= 0.3.1
 babel ~= 2.7.0
 django-debug-toolbar
 gevent
+pymarker


### PR DESCRIPTION
## Description

This issue includes bring the part of generating a marker, already to the form of sending a marker.

## Resolves (Issues)

#249 

## General tasks performed
* Using pymarker to generate marker
* Separate the object form from the marker form
* Save marker in database

@MatheusBlanco helped me with this issue.

### Have you confirmed the application builds locally without error? See [here](https://github.com/memeLab/Jandig#running).

- [ ] Yes
- [X] No

:skull_and_crossbones: :skull_and_crossbones:  Reason: This issues uses a [pymarker](https://github.com/pablodiegoss/pymarker) lib, which contains a bug when trying to submit a transparent marker.

For transparent images instead of the generated marker having a white background, it ends up turning all black.
Example:
Image
![sleep](https://user-images.githubusercontent.com/35435199/101509676-c67dc000-3957-11eb-91f3-0869368d0a52.png)

Generated Marker:
![marker](https://user-images.githubusercontent.com/35435199/100924358-45d64400-34bf-11eb-9854-8b55966425a0.png)

:smiley: :smiley: Me, @manueng and @darmsDD  have already solved this problem in the [pymarker](https://github.com/pablodiegoss/pymarker)  and as soon as the PR is accepted, this bug will be fixed here.
