### PR TITLE
[WIP] 367 - Fix frontend error message for duplicated exhibit name and slugs

### DIFF
--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -136,6 +136,15 @@ msgstr "Título da Exposição"
 msgid "Exhibit URL"
 msgstr "URL da exposição"
 
+#: src/ARte/users/forms.py:247
+msgid "Duplicated slug. Please choose another slug for your exhibit."
+msgstr "Slug Duplicado. Por favor escolha outro slug para sua exibição."
+
+#: src/ARte/users/forms.py:249
+msgid "Duplicated name. Please choose another name for your exhibit."
+msgstr "Nome Duplicado. Por favor escolhar outro nome para sua exibição."
+
+
 #: src/ARte/core/jinja2/core/base.jinja2:44
 #, fuzzy
 msgid "Please override the \"content\" block of your template!"

--- a/src/ARte/users/forms.py
+++ b/src/ARte/users/forms.py
@@ -239,13 +239,15 @@ class ExhibitForm(forms.Form):
     artworks = forms.CharField(max_length=1000)
 
     def clean_slug(self):
-        data = self.cleaned_data['slug']
+        slug = self.cleaned_data['slug']
         name = self.cleaned_data['name']
-        if not re.match("^[a-zA-Z0-9_]*$", data):
+        if not re.match("^[a-zA-Z0-9_]*$", slug):
             raise forms.ValidationError(_("Url can't contain spaces or special characters"))
+        if Exhibit.objects.filter(slug=slug).exists():
+            raise forms.ValidationError(_("Duplicated slug. Please choose another slug for your exhibit."))
         if Exhibit.objects.filter(name=name).exists():
-            raise forms.ValidationError(_("Duplicated name"))
-        return data
+            raise forms.ValidationError(_("Duplicated name. Please choose another name for your exhibit."))
+        return slug
 
     def __init__(self, *args, **kwargs):
         super(ExhibitForm, self).__init__(*args, **kwargs)

--- a/src/ARte/users/forms.py
+++ b/src/ARte/users/forms.py
@@ -9,6 +9,7 @@ from django.contrib.auth.forms import UserCreationForm, AuthenticationForm
 from django.contrib.auth.forms import PasswordChangeForm as OrigPasswordChangeForm
 from django.utils.translation import ugettext_lazy as _
 from django.forms.widgets import HiddenInput
+from core.models import Exhibit
 
 from .models import Marker, Object, Artwork, Profile
 
@@ -239,8 +240,11 @@ class ExhibitForm(forms.Form):
 
     def clean_slug(self):
         data = self.cleaned_data['slug']
+        name = self.cleaned_data['name']
         if not re.match("^[a-zA-Z0-9_]*$", data):
             raise forms.ValidationError(_("Url can't contain spaces or special characters"))
+        if Exhibit.objects.filter(name=name).exists():
+            raise forms.ValidationError(_("Duplicated name"))
         return data
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
## Description

Added validation for unique constraints in exhibit name and in case there is already a name taken, raise validation error to frontend 

## Resolves (Issues)

#367 

## General tasks performed
* Return to frontend validation error if there is already a exhibit using chosen name
* Translate message error to PT-BR

### Have you confirmed the application builds locally without error? See [here](https://github.com/memeLab/Jandig#running).
- [X ] Yes