### PR TITLE
[REVIEW] 375 - Add new issue template to feature request

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,9 @@
 ---
 name: Bug report
 about: Report a bug to help us improve Jandig
+title: ''
+labels: bug
+assignees: ''
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature Request
+about: I have a suggestion to Jandig (and may want to implement it)!
+title: ''
+labels: feature, enhancement
+assignees: ''
+
+---
+
+## Feature Request
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I have an issue when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen. Add any considered drawbacks.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Is there anything else you can add about the proposal? Maybe a screenshot or design?


### PR DESCRIPTION
## Description

Add new issue template to feature request under `.github/ISSUE_TEMPLATE` folder.

## Resolves (Issues)

Resolves: #375

## General tasks performed

- [x] Create issue template to request new features to Jandig.app.

* The issue template is based on other templates from open source projects.

### Have you confirmed the application builds locally without error? See [here](https://github.com/memeLab/Jandig#running)

- [x] Yes