### PR TITLE
[REVIEW] 338 - Changing the 'no collection' message

### DIFF
--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -630,6 +630,11 @@ msgstr "Curador Jandig"
 msgid "No Exhibitions yet."
 msgstr "Sem Exposições ainda."
 
+#: src/ARte/core/jinja2/core/collection.jinja2:53
+msgid "We found no content on your Collection, try uploading an object."
+msgstr "Não encontramos nenhum conteudo dentro da sua Coleção. Tente fazer upload de um Objeto antes."
+
+
 #~ msgid " exhibits"
 #~ msgstr " exposições"
 


### PR DESCRIPTION
## Description
Changed the message "This element isn't being used yet. :(" to a new message that represent the current state of the database and a hint of what action the user can perform to not receive that message.

![image](https://user-images.githubusercontent.com/37215459/109695553-ccf09200-7b6a-11eb-8651-f266e23237e0.png)

## Resolves (Issues)

#338 

## General tasks performed
Changed the message on collection.jinja2 file.
### Have you confirmed the application builds locally without error? See [here](https://github.com/memeLab/Jandig#running).
- [X] Yes