### PR TITLE
[REVIEW] 392-titles-django-admin

### DIFF
--- a/src/ARte/users/models.py
+++ b/src/ARte/users/models.py
@@ -13,6 +13,9 @@ class Profile(models.Model):
     country = models.CharField(max_length=2, choices=COUNTRY_CHOICES, blank=True)
     personal_site = models.URLField()
 
+    def __str__(self):
+        return self.user
+
     class Meta:
         permissions = [
             ("moderator", "Can moderate content"),
@@ -200,6 +203,9 @@ class Artwork(models.Model):
     title = models.CharField(max_length=50, blank=False)
     description = models.TextField(max_length=500, blank=True)
     created_at = models.DateTimeField(auto_now=True)
+
+    def __str__(self):
+        return self.title
 
     @property
     def exhibits_count(self):


### PR DESCRIPTION
Co-authored-by: ZarathosDeath <nando_rhapsody@hotmail.com>
## Description
Objects titles now are showing as asked on Profile and Artwork tabs

## Resolves (Issues)

Resolves: #392 

## General tasks performed
Added __str__ method on the classes that didn't have (Artwork and Profile)

### Have you confirmed the application builds locally without error? See [here](https://github.com/memeLab/Jandig#running).
- [X] Yes
- 
![image](https://user-images.githubusercontent.com/37215459/112351975-2307af80-8ca9-11eb-8f87-1e147bf2f24d.png)
![image](https://user-images.githubusercontent.com/37215459/112352037-30bd3500-8ca9-11eb-9d2d-abd118f512ff.png)
