### PR TITLE
[REVIEW] 396 - response used before defined

### DIFF
--- a/src/ARte/users/tests.py
+++ b/src/ARte/users/tests.py
@@ -17,8 +17,8 @@ class UserTestCase(TestCase):
     
         request = self.client_test.get('/recover/', follow=True)
     def test_redirect_to_recover_password_page(self):
-        self.assertEqual(response.status_code, 200)
         response = recover_password(request)
+        self.assertEqual(response.status_code, 200)
 
     def test_recover_password_invalid_email(self):
         request = self.client_test.post('/recover/', {'username_or_email': 'testadorinvalid@memelab.com'}, follow=True)


### PR DESCRIPTION
## Description
The variable now is being defined before used on tests.py

## Resolves (Issues)
#396 

## General tasks performed
* Switched the order from lines on tests.py file

##Screenshots
![image](https://user-images.githubusercontent.com/37215459/113653187-b8bd1a80-966b-11eb-9beb-ba21fa233bb0.png)


### Have you confirmed the application builds locally without error? See [here](https://github.com/memeLab/Jandig#running).
- [x] Yes
