### PR TITLE
[REVIEW] 391 - Issue template to refactoring proposal

### DIFF
--- a/.github/ISSUE_TEMPLATE/refactoring.md
+++ b/.github/ISSUE_TEMPLATE/refactoring.md
@@ -1,0 +1,27 @@
+---
+name: Refactoring proposal
+about: Suggest a way to improve our source code
+title: ''
+labels: code
+assignees: ''
+
+---
+
+## Refactoring Proposal
+
+**Describe the design issue(s) you have identified in the code**
+Clear and concise description of code smells, technical debits or general code improvements.
+
+**Which source files are affected to this issue(s)?**
+Clear and concise list of relative paths to files that are affected to this issue.
+
+1. Relative path to file 1;
+2. Relative path to file 2;
+3. Etc.
+
+**Describe refactoring alternatives to redesign the code**
+Clear and concise list with descriptions of how to refactor the code. Maybe [potential solutions from the refactoring catalog](https://refactoring.com/catalog/).
+
+1. Refactoring 1;
+2. Refactoring 2;
+3. Etc.


### PR DESCRIPTION
## Description

Add new issue template to refactoring proposals in the Jandig source code.

## Resolves (Issues)

Resolve #391.

## General tasks performed

* Add `refactoring.md` file to `.github/ISSUE_TEMPLATES` folder;
* Add issue template to refactoring proposal to this repository.

### Have you confirmed the application builds locally without error? See [here](https://github.com/memeLab/Jandig#running).
- [x] Yes