### PR TITLE
[REVIEW] #432 - Create Security Policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+This document aims to provide instructions about how to report security vulnerabilities. Jandig, as an open-source community, prizes this kind of interaction since we'll use these pieces of information for tracking and correcting defects.
+
+
+## Reporting Security Issues
+
+At Jandig, we value keeping the security integrity of the platform. Therefore, vulnerabilities reports and issues related to security are welcome and must be made through GitHub issues.
+Before creating a report issue, you must collect data about the vulnerability, such as print screens and paths for reaching the problem. Once you have collected all the information needed to reproduce the error, you must now describe it as a bug report issue. You can find more details about how to create a issue on [CONTRIBUTING](https://github.com/memeLab/Jandig/blob/develop/.github/CONTRIBUTING.md) document.    
+
+
+## Language
+
+We prefer to keep all internal communication of the project in English.


### PR DESCRIPTION
## Description

Creation of security policy of the project. In this document we describe how to relate vulnerabilities issues and Jandig's point of view on users security.

## Resolves

Resolves #432 

## General tasks performed
* Creation of Security Policy document.

### Have you confirmed the application builds locally without error? See [here](https://github.com/memeLab/Jandig#running).
- [x] Yes