### PR TITLE
[REVIEW] 429 - Undesired words and blank space

### DIFF
--- a/src/ARte/users/jinja2/users/components/object-position.jinja2
+++ b/src/ARte/users/jinja2/users/components/object-position.jinja2
@@ -6,12 +6,6 @@
         <div id="box-shadow-container">
             <div id="box-shadow"></div>
         </div>
-        <div class="row">
-            <div class='box object-color-box'></div><span>Objeto</span>
-        </div>
-        <div class="row">
-            <div class='box marker-color-box'></div><span>Marcador</span>
-        </div>
         <h3>Horizontal:</h3>
         <div class="slider-container"> 
             <input id="X-position" type="range" min="-100" max="100" class="trigger-change-value slider" value="{{ xposition }}" oninput="updateXValue()">


### PR DESCRIPTION
## Description

We've searched the code together and found and fixed the problem about the two words by removing them from the objetc-position.jinja2 file. However, the blank space was actually that we couldn't see a square in the page, which was also fixed.

## Resolves (Issues)

Resolve #429 


## General tasks performed
* Remove both undesired words
* Fix blank space

### Have you confirmed the application builds locally without error? See [here](https://github.com/memeLab/Jandig#running).
- [x] Yes