### PR TITLE
[REVIEW] 428 - No login error message when there's a space in the field

### DIFF
--- a/src/ARte/users/forms.py
+++ b/src/ARte/users/forms.py
@@ -144,6 +144,9 @@ class LoginForm(AuthenticationForm):
         user = None
         username_or_email_wrong = False
 
+        if ' ' in username_or_email:
+            raise forms.ValidationError(_(f'Username/email not found'))
+
         if '@' in username_or_email:
             if User.objects.filter(email=username_or_email).exists():
                 username = User.objects.get(email=username_or_email).username


### PR DESCRIPTION
## Description

After some investigation about how the project handles authentication, the best solution we could find was to check if there is a white space in the username/email and raise an exception.

## Resolves (Issues)

Fix #428 

## General tasks performed
* Check if there is a white space in the username/email
* Raise an exception with the error message "Username/email not found"

### Have you confirmed the application builds locally without error? See [here](https://github.com/memeLab/Jandig#running).
- [x] Yes