### PR TITLE
[REVIEW]  293 - Change the sender name of the password recovery email to Jandig

### DIFF
--- a/src/ARte/users/services/email_service.py
+++ b/src/ARte/users/services/email_service.py
@@ -3,7 +3,6 @@ import os
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
-
 class EmailService:
     def __init__(self, email_message):
         self.smtp_server = os.environ.get("SMTP_SERVER", "smtp.gmail.com")
@@ -15,7 +14,7 @@ class EmailService:
     def send_email_to_recover_password(self, multipart_message):
         email_server = smtplib.SMTP(self.smtp_server, self.smtp_port)
         email_server.starttls()
-        email_server.login(multipart_message["From"], self.jandig_email_password)
+        email_server.login(self.jandig_email, self.jandig_email_password)
         email_server.sendmail(
             multipart_message["From"],
             multipart_message["To"],
@@ -24,8 +23,8 @@ class EmailService:
         email_server.quit()
 
     def build_multipart_message(self, user_email):
-        multipart_message = MIMEMultipart()
-        multipart_message["From"] = self.jandig_email
+        multipart_message = MIMEMultipart('alternative')
+        multipart_message["From"] = f'Jandig <{self.jandig_email}>'
         multipart_message["To"] = "{}".format(user_email)
         multipart_message["Subject"] = "Recover Password"
 


### PR DESCRIPTION
## Description

Change the friendly name of the email sender to 'Jangid' instead of 'jandig@memelab.com', in the recovery password system.

## Resolves (Issues)

Fix #293 

## General tasks performed
* Changed the variable used for login.
* Added alias with login variable in the variable used in email body.

### Have you confirmed the application builds locally without error? See [here](https://github.com/memeLab/Jandig#running).
- [x] Yes