### PR TITLE
Feature/367 Fix frontend error message for duplicated exhibit name and slugs

### DIFF
--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -142,7 +142,7 @@ msgstr "Complete sua URL de exibição aqui"
 
 #: src/ARte/users/forms.py:248
 msgid "That exhibit slug is already in use. Please choose another slug for your exhibit."
-msgstr "O Slug desta exibição ja esta sendo usado. Por favor escolha outro slug para sua exibição."
+msgstr "Este link de exibição já está sendo utilizado. Por favor escolha outro link para sua exibição."
 
 #: src/ARte/users/forms.py:250
 msgid "Duplicated name. Please choose another name for your exhibit."

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -140,6 +140,14 @@ msgstr "URL da exposição"
 msgid "Complete with your Exhibit URL here"
 msgstr "Complete sua URL de exibição aqui"
 
+#: src/ARte/users/forms.py:248
+msgid "That exhibit slug is already in use. Please choose another slug for your exhibit."
+msgstr "O Slug desta exibição ja esta sendo usado. Por favor escolha outro slug para sua exibição."
+
+#: src/ARte/users/forms.py:250
+msgid "Duplicated name. Please choose another name for your exhibit."
+msgstr "O nome desta exibição ja esta sendo usado. Por favor escolhar outro nome para sua exibição."
+
 #: src/ARte/core/jinja2/core/base.jinja2:44
 #, fuzzy
 msgid "Please override the \"content\" block of your template!"

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -146,7 +146,7 @@ msgstr "Este link de exibição já está sendo utilizado. Por favor escolha out
 
 #: src/ARte/users/forms.py:250
 msgid "Duplicated name. Please choose another name for your exhibit."
-msgstr "O nome desta exibição ja esta sendo usado. Por favor escolhar outro nome para sua exibição."
+msgstr "Este nome de exibição já está em uso. Por favor, escolha outro nome."
 
 #: src/ARte/core/jinja2/core/base.jinja2:44
 #, fuzzy

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -145,7 +145,7 @@ msgid "That exhibit slug is already in use. Please choose another slug for your 
 msgstr "Este link de exibição já está sendo utilizado. Por favor escolha outro link para sua exibição."
 
 #: src/ARte/users/forms.py:250
-msgid "Duplicated name. Please choose another name for your exhibit."
+msgid "This name is already being used. Please choose another name for your exhibit."
 msgstr "Este nome de exibição já está em uso. Por favor, escolha outro nome."
 
 #: src/ARte/core/jinja2/core/base.jinja2:44

--- a/src/ARte/users/forms.py
+++ b/src/ARte/users/forms.py
@@ -9,6 +9,7 @@ from django.contrib.auth.forms import UserCreationForm, AuthenticationForm
 from django.contrib.auth.forms import PasswordChangeForm as OrigPasswordChangeForm
 from django.utils.translation import ugettext_lazy as _
 from django.forms.widgets import HiddenInput
+from core.models import Exhibit
 
 from core.models import Marker, Object, Artwork
 from .models import Profile
@@ -239,10 +240,15 @@ class ExhibitForm(forms.Form):
     artworks = forms.CharField(max_length=1000)
 
     def clean_slug(self):
-        data = self.cleaned_data['slug']
-        if not re.match("^[a-zA-Z0-9_]*$", data):
+        slug = self.cleaned_data['slug']
+        name = self.cleaned_data['name']
+        if not re.match("^[a-zA-Z0-9_]*$", slug):
             raise forms.ValidationError(_("Url can't contain spaces or special characters"))
-        return data
+        if Exhibit.objects.filter(slug=slug).exists():
+            raise forms.ValidationError(_("That exhibit slug is already in use. Please choose another slug for your exhibit."))
+        if Exhibit.objects.filter(name=name).exists():
+            raise forms.ValidationError(_("That exhibit name is already in use. Please choose another name for your exhibit."))
+        return slug
 
     def __init__(self, *args, **kwargs):
         super(ExhibitForm, self).__init__(*args, **kwargs)


### PR DESCRIPTION
## Description

Fix frontend error message for duplicated exhibit name and slugs

## Resolves (Issues)

Resolve #367

## General tasks performed
* Fix frontend error message for duplicated exhibit name and slugs
* Change texts "Duplicated slug. Please choose another slug for your exhibit." to "That exhibit slug is already in use. Please choose another slug for your exhibit."
* Translated messages

### Have you confirmed the application builds locally without error? See [here](https://github.com/memeLab/Jandig#running).
- [ ] Yes