### PR TITLE
[REVIEW] - Add link to create an artwork when there is no artwork

### DIFF
--- a/src/ARte/users/jinja2/users/exhibit-create.jinja2
+++ b/src/ARte/users/jinja2/users/exhibit-create.jinja2
@@ -20,7 +20,17 @@
                 <div id="marker-modal" class="tab">
                     <h4 class="modal-title">{{ _('Select Artworks (1/2)') }}</h4>
 
-                    <p class="gallery-title">{{ _('Choose from your repository') }}</p>
+                    {% if repository_list %}
+                        <p class="gallery-title">{{ _('Choose from your repository') }}</p>
+
+                    {% else %}
+                        <section id="repo-{{element_type}}" class="repository-list">
+                            <p>{{_("You have no Artworks. :c")}}</p>
+                            <a href="{{ url('create-artwork') }}" class="select-btn">
+                                {{ _('Create one') }}
+                            </a>
+                        </section>
+                    {% endif %}
 
                     {% with repository_list = artworks, element_type="artwork", selected=selected_artworks %}
                         {% include "users/components/artworks-list.jinja2" %}
@@ -51,8 +61,8 @@
             </form>
         </div>
         <script>
-            const MARKER_TAB = 0; 
-            const ARTWORK_TAB = 1; 
+            const MARKER_TAB = 0;
+            const ARTWORK_TAB = 1;
 
             let currentTab = MARKER_TAB;
             function showTab(tabNumber){
@@ -83,7 +93,7 @@
                 let validate = /^[a-zA-Z0-9_]*$/
                 if (!slug.match(validate)) {
                     alert("{{ _("Urls can't contain spaces or special characters (i.e: .:, /)") }}")
-                }   
+                }
             }
 
             setInterval(activateNextButton, 100);


### PR DESCRIPTION
## Description

While I was populating the development environment, I noticed that the form for creating an exhibition asks to select artworks, but since there was none, it was a meaningless form.

I added a condition in the form code to redirect the user to the artworks form in scenarios where there are no artworks.

| Before | After |
| :-: | :-: |
| <img src="https://user-images.githubusercontent.com/31013187/198388323-4c5cb7e5-f1f0-445a-90d0-441e3638059f.png" width="800"> | <img src="https://user-images.githubusercontent.com/31013187/198388854-7896852d-1cf5-4752-a4e6-6ee7204a183d.png" width="800"> | 


### Have you confirmed the application builds locally without error? See [here](https://github.com/memeLab/Jandig#running).
- [X] Yes