### PR TITLE
Remove the whitenoise lib from the project

### DIFF
--- a/docs/real_docs/development-server.md
+++ b/docs/real_docs/development-server.md
@@ -1,9 +1,9 @@
 ## Welcome to the development server guide
 
-Run the local development server using sqlite as database and serving static files with whitenoise (-w flag). The server will be available at http://localhost:8000.
+Run the local development server. The server will be available at http://localhost:8000.
 
 ```shell
-$ inv db collect run -w
+$ inv db -p collect run -w
 ```
 
 With the previous command you can use ARte only on the local machine running the server. Because of security protocols, other devices must access through a ssl (https) connection. To do this, we use [ngrok](https://ngrok.com/download). The ngrok will generate a https url pointing to your local server, so you can access ARte through external devices.

--- a/poetry.lock
+++ b/poetry.lock
@@ -687,17 +687,6 @@ secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "cer
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
-name = "whitenoise"
-version = "6.2.0"
-description = "Radically simplified static file serving for WSGI applications"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-
-[package.extras]
-brotli = ["brotli"]
-
-[[package]]
 name = "zope.event"
 version = "4.5.0"
 description = "Very basic event publishing system"
@@ -725,7 +714,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "4114117ffa1457b2056a93372024dcc0935865c61d902adfdddfe9f58f5ecb5f"
+content-hash = "8a456725eead715c37323e82e0b0c7ee95e16d26715a2cb8711493ee6dfd7404"
 
 [metadata.files]
 alabaster = []
@@ -932,6 +921,5 @@ sqlparse = []
 toolz = []
 tzdata = []
 urllib3 = []
-whitenoise = []
 "zope.event" = []
 "zope.interface" = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ factory-boy = "^3.2.1"
 boto3 = "^1.24.27"
 django-storages = "^1.12.3"
 sentry-sdk = "^1.7.0"
-whitenoise = "^6.2.0"
 click = "^8.1.3"
 djangorestframework = "^3.13.1"
 

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 poetry show
-poetry run inv db -p i18n --compile docs run -p -g
+poetry run inv collect db -p i18n --compile docs run -p -g

--- a/src/.envs/.example
+++ b/src/.envs/.example
@@ -6,7 +6,7 @@ DJANGO_ADMIN_URL=admin/
 DEV_DB=False
 DEV_STATIC=True
 DEBUG_TOOLBAR=True
-DJANGO_SECRET_KEY=
+DJANGO_SECRET_KEY=change_me
 USE_MINIO=True
 
 ## Amazon AWS Variables

--- a/src/ARte/config/settings.py
+++ b/src/ARte/config/settings.py
@@ -220,10 +220,11 @@ if USE_MINIO:
     AWS_S3_CUSTOM_DOMAIN = f"localhost:9000/{AWS_STORAGE_BUCKET_NAME}"
     AWS_S3_USE_SSL = False
     AWS_S3_SECURE_URLS = False
-    HTTP_PROTOCOL = "http"
+    AWS_S3_URL_PROTOCOL = "http:"
+
 else:
     AWS_S3_CUSTOM_DOMAIN = f"{AWS_STORAGE_BUCKET_NAME}.s3.amazonaws.com"
-    HTTP_PROTOCOL = "https"
+    AWS_S3_URL_PROTOCOL = "https:"
 
 # Static configuration
 # Add your own apps statics in this list
@@ -233,11 +234,10 @@ STATICFILES_DIRS = [
 ]
 COLLECT_DIR = os.path.dirname(os.path.dirname(BASE_DIR))
 STATIC_ROOT = os.path.join(COLLECT_DIR, 'collect')
-STATIC_URL = f"{HTTP_PROTOCOL}//{AWS_S3_CUSTOM_DOMAIN}/{AWS_STATIC_LOCATION}/"
 STATICFILES_STORAGE = "config.storage_backends.StaticStorage"
 
 MEDIA_ROOT = os.path.join(BASE_DIR, 'users', 'media')
-MEDIA_URL = f"{HTTP_PROTOCOL}//{AWS_S3_CUSTOM_DOMAIN}/{AWS_MEDIA_LOCATION}/"
+# MEDIA_URL = f"{AWS_S3_URL_PROTOCOL}//{AWS_S3_CUSTOM_DOMAIN}/{AWS_MEDIA_LOCATION}/"
 
 AWS_PUBLIC_MEDIA_LOCATION = "media/public"
 DEFAULT_FILE_STORAGE = "config.storage_backends.PublicMediaStorage"

--- a/src/ARte/config/settings.py
+++ b/src/ARte/config/settings.py
@@ -94,12 +94,6 @@ def debug(request):
     return env.bool('DEBUG_TOOLBAR', False)
 
 
-## Let whitenoise serve static files  -- DON'T USE IN PRODUCTION --
-if env.bool('DEV_STATIC', False):
-    MIDDLEWARE.insert(1, 'whitenoise.middleware.WhiteNoiseMiddleware')
-    STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
-    print('\n ------- SERVING STATIC FILES USING WHITENOISE! -------\n')
-
 ROOT_URLCONF = 'config.urls'
 
 PAGE_SIZE = 20

--- a/src/ARte/core/jinja2/core/collection.jinja2
+++ b/src/ARte/core/jinja2/core/collection.jinja2
@@ -25,7 +25,7 @@
                         {% include "users/components/item-list.jinja2" %}
                     {% endwith %}
                     {% if seeall == False %}
-                    <a href = "/see_all?which=artworks" class="seeall">{{_("All Artworks")}}</a>
+                    <a href = "/see_all/?which=artworks" class="seeall">{{_("All Artworks")}}</a>
                     {% endif %}
                 {% endif %}
 
@@ -35,7 +35,7 @@
                         {% include "users/components/item-list.jinja2" %}
                     {% endwith %}
                     {% if seeall == False %}
-                    <a href= "/v1/markers" class="seeall">{{_("All Markers")}}</a>
+                    <a href= "/v1/markers/" class="seeall">{{_("All Markers")}}</a>
                     {% endif %}
                 {% endif %}
 
@@ -45,7 +45,7 @@
                         {% include "users/components/item-list.jinja2" %}
                     {% endwith%}
                     {% if seeall == False %}
-                    <a href= "/see_all?which=objects" class="seeall">{{_("All Objects")}}</a>
+                    <a href= "/see_all/?which=objects" class="seeall">{{_("All Objects")}}</a>
                     {% endif %}
                 {% endif %}
 

--- a/tasks.py
+++ b/tasks.py
@@ -20,27 +20,26 @@ def robust_manage(ctx, cmd, env=None, **kwargs):
     ctx.run(cmd, pty=True, env=env)
 
 
-def manage(ctx, cmd, postgres=False, whitenoise=False):
+def manage(ctx, cmd, postgres=False):
     cmd = f'python3 src/ARte/manage.py {cmd}'
-    ctx.run(cmd, pty=True, env=default_env(postgres, whitenoise))
+    ctx.run(cmd, pty=True, env=default_env(postgres))
 
 
-def default_env(postgres, whitenoise):
+def default_env(postgres):
     os.environ['DEV_DB'] = 'True' if not postgres else 'False'
-    os.environ['DEV_STATIC'] = 'True' if whitenoise else 'False'
     e = os.environ
     return e
 
 
 @task
-def run(ctx, ssl=False, gunicorn=False, postgres=False, whitenoise=False):
+def run(ctx, ssl=False, gunicorn=False, postgres=False):
     """
     Run development server
     """
     if gunicorn:
         ctx.run('cd src/ARte && gunicorn --worker-connections=10000 --workers=4 --log-level debug --bind 0.0.0.0:8000 config.wsgi', env={"DEV_DB":"False"})
     else:
-        manage(ctx, "runserver 0.0.0.0:8000", postgres, whitenoise)
+        manage(ctx, "runserver 0.0.0.0:8000", postgres)
     
 
 


### PR DESCRIPTION
## Description

The whitenoise lib was an old way of serving static files in the project, this was later replaced by MINIO that uses the same structure as an AWS S3 bucket. However the URL protocol for localhosts used to retrieve statics on MINIO was updated and didn't work.

## General tasks performed
- Fixed MINIO variable for URL protocol
- Removed all tasks, scripts, requirements and documentation about the whitenoise lib
- Fixed a redirect to the All Markers page

* Task 2

### Have you confirmed the application builds locally without error? See [here](https://github.com/memeLab/Jandig#running).
- [x] Yes