### PR TITLE
[Review] 428 - no login error message when there's a space in the field

### DIFF
--- a/src/users/forms.py
+++ b/src/users/forms.py
@@ -160,7 +160,7 @@ class LoginForm(AuthenticationForm):
 
     def clean_password(self):
         password = self.cleaned_data.get("password")
-        username_or_email = self.data.get("username")
+        username_or_email = self.cleaned_data.get("username")
         user = None
         username_or_email_wrong = False
 


### PR DESCRIPTION
## Description

The pull request changes the function used to get the username/email on the login page

## Resolves (Issues)

#428 

## General tasks performed
* Changed the function `self.data.get("username")` to `self.cleaned_data.get("username")`

### Have you confirmed the application builds locally without error? See [here](https://github.com/memeLab/Jandig#running).
- [x] Yes