### PR TITLE
[Review] 515 - Completing login screen translation

### DIFF
--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -504,6 +504,10 @@ msgstr "Digite seu nome de usuário ou email"
 msgid "Remember me"
 msgstr "Lembre-se de mim"
 
+#: src/ARte/users/jinja2/users/login.jinja2:35
+msgid "Remember me"
+msgstr "Lembre-se de mim"
+
 #: src/ARte/users/jinja2/users/components/createbox.jinja2:5
 #: src/ARte/users/jinja2/users/upload.jinja2:10
 msgid "Upload Marker"


### PR DESCRIPTION
## Description

A translation from English to Portuguese of the missing points on the login screen was carried out.

## Resolves (Issues)

#515

## General tasks performed
* Login screen translation

### Have you confirmed the application builds locally without error? See [here](https://github.com/memeLab/Jandig#running).
- [x] Yes