### PR TITLE
Improve Object and Marker admin pages

### DIFF
--- a/src/core/admin.py
+++ b/src/core/admin.py
@@ -7,9 +7,18 @@ from core.models import Artwork, Exhibit, Marker, Object
 from django.utils.html import format_html
 
 admin.site.register(Exhibit)
-admin.site.register(Object)
 admin.site.register(Artwork)
 
+def create_link_to_related_artworks(obj):
+    """Link to related Artworks"""
+    if obj.artworks_count == 0:
+        return obj._artworks_count
+    # Artwork IDs split by commas
+    artworks_list = obj.artworks_list.values_list("id", flat=True)
+    artworks_list = ",".join([str(i) for i in artworks_list])
+
+    link = reverse("admin:index") + "core/artwork/?id__in=" + str(artworks_list)
+    return format_html('<a href="{}">{}</a>', link, obj._artworks_count)
 
 @admin.register(Marker)
 class MarkerAdmin(admin.ModelAdmin):
@@ -22,7 +31,7 @@ class MarkerAdmin(admin.ModelAdmin):
         "artworks_count",
         "exhibits_count",
         "uploaded_at",
-        "file_size",
+        "filesize",
     ]
     search_fields = ["title", "id"]
     ordering = ["-uploaded_at"]
@@ -41,15 +50,7 @@ class MarkerAdmin(admin.ModelAdmin):
         return queryset
 
     def artworks_count(self, obj):
-        """Link to related Artworks"""
-        if obj.artworks_count == 0:
-            return obj._artworks_count
-        # Artwork IDs split by commas
-        artworks_list = obj.artworks_list.values_list("id", flat=True)
-        artworks_list = ",".join([str(i) for i in artworks_list])
-
-        link = reverse("admin:index") + "core/artwork/?id__in=" + str(artworks_list)
-        return format_html('<a href="{}">{}</a>', link, obj._artworks_count)
+        return create_link_to_related_artworks(obj)
 
     def exhibits_count(self, obj):
         return obj._exhibits_count
@@ -59,5 +60,70 @@ class MarkerAdmin(admin.ModelAdmin):
             '<img src="{}" style="height:200px; width:200px;"/>', obj.source.url
         )
 
+    def filesize(self, obj):
+        """File size in MB"""
+        if obj.file_size > 0:
+            return f"{obj.file_size / 1024 / 1024:.2f} MB"
+        return obj.file_size
+    
+
+    filesize.short_description = "File Size"
+    filesize.admin_order_field = "file_size"
     artworks_count.admin_order_field = "_artworks_count"
     exhibits_count.admin_order_field = "_exhibits_count"
+
+@admin.register(Object)
+class ObjectAdmin(admin.ModelAdmin):
+    list_display = [
+        "title",
+        "image_preview",
+        "id",
+        "owner",
+        "author",
+        "artworks_count",
+        "exhibits_count",
+        "filesize",
+        "uploaded_at",
+    ]
+    search_fields = ["title", "id"]
+    ordering = ["-uploaded_at"]
+
+    def get_queryset(self, request):
+        queryset = (
+            super()
+            .get_queryset(request)
+            .select_related("owner")
+            .prefetch_related("artworks", "artworks__exhibits")
+        )
+        queryset = queryset.annotate(
+            _artworks_count=Count("artworks", distinct=True),
+            _exhibits_count=Count("artworks__exhibits", distinct=True),
+        )
+        return queryset
+
+    def artworks_count(self, obj):
+        return create_link_to_related_artworks(obj)
+
+    def exhibits_count(self, obj):
+        return obj._exhibits_count
+
+    def image_preview(self, obj):
+        """Image preview with proportions"""
+        max_height = 200
+        max_width = 200
+        height = max_height * obj.yproportion
+        width = max_width * obj.xproportion
+        return format_html(
+            '<img src="{}" style="height:{}px; width:{}px;"/>', obj.source.url, height, width
+        )
+    
+    def filesize(self, obj):
+        """File size in MB"""
+        if obj.file_size > 0:
+            return f"{obj.file_size / 1024 / 1024:.2f} MB"
+        return obj.file_size
+
+    filesize.short_description = "File Size"
+    filesize.admin_order_field = "file_size"
+    # artworks_count.admin_order_field = "_artworks_count"
+    # exhibits_count.admin_order_field = "_exhibits_count"

--- a/src/core/admin.py
+++ b/src/core/admin.py
@@ -22,8 +22,7 @@ def create_link_to_related_artworks(obj):
     return format_html('<a href="{}">{}</a>', link, obj._artworks_count)
 
 
-@admin.register(Marker)
-class MarkerAdmin(admin.ModelAdmin):
+class BaseMarkerObjectAdmin(admin.ModelAdmin):
     list_display = [
         "title",
         "image_preview",
@@ -57,11 +56,6 @@ class MarkerAdmin(admin.ModelAdmin):
     def exhibits_count(self, obj):
         return obj._exhibits_count
 
-    def image_preview(self, obj):
-        return format_html(
-            '<img src="{}" style="height:200px; width:200px;"/>', obj.source.url
-        )
-
     def filesize(self, obj):
         """File size in MB"""
         if obj.file_size > 0:
@@ -74,42 +68,17 @@ class MarkerAdmin(admin.ModelAdmin):
     exhibits_count.admin_order_field = "_exhibits_count"
 
 
+@admin.register(Marker)
+class MarkerAdmin(BaseMarkerObjectAdmin):
+    def image_preview(self, obj):
+        return format_html(
+            '<img src="{}" style="height:200px; width:200px;"/>', obj.source.url
+        )
+
+
 @admin.register(Object)
-class ObjectAdmin(admin.ModelAdmin):
-    list_display = [
-        "title",
-        "preview",
-        "id",
-        "owner",
-        "author",
-        "artworks_count",
-        "exhibits_count",
-        "filesize",
-        "uploaded_at",
-    ]
-    search_fields = ["title", "id"]
-    ordering = ["-uploaded_at"]
-
-    def get_queryset(self, request):
-        queryset = (
-            super()
-            .get_queryset(request)
-            .select_related("owner")
-            .prefetch_related("artworks", "artworks__exhibits")
-        )
-        queryset = queryset.annotate(
-            _artworks_count=Count("artworks", distinct=True),
-            _exhibits_count=Count("artworks__exhibits", distinct=True),
-        )
-        return queryset
-
-    def artworks_count(self, obj):
-        return create_link_to_related_artworks(obj)
-
-    def exhibits_count(self, obj):
-        return obj._exhibits_count
-
-    def preview(self, obj):
+class ObjectAdmin(BaseMarkerObjectAdmin):
+    def image_preview(self, obj):
         """Image preview with proportions"""
         max_height = 200
         max_width = 200
@@ -128,14 +97,3 @@ class ObjectAdmin(admin.ModelAdmin):
             height,
             width,
         )
-
-    def filesize(self, obj):
-        """File size in MB"""
-        if obj.file_size > 0:
-            return f"{obj.file_size / 1024 / 1024:.2f} MB"
-        return obj.file_size
-
-    filesize.short_description = "File Size"
-    filesize.admin_order_field = "file_size"
-    # artworks_count.admin_order_field = "_artworks_count"
-    # exhibits_count.admin_order_field = "_exhibits_count"

--- a/src/core/admin.py
+++ b/src/core/admin.py
@@ -1,8 +1,63 @@
 from django.contrib import admin
 
+from django.urls import reverse
+from django.db.models import Count
 from core.models import Artwork, Exhibit, Marker, Object
+
+from django.utils.html import format_html
 
 admin.site.register(Exhibit)
 admin.site.register(Object)
-admin.site.register(Marker)
 admin.site.register(Artwork)
+
+
+@admin.register(Marker)
+class MarkerAdmin(admin.ModelAdmin):
+    list_display = [
+        "title",
+        "image_preview",
+        "id",
+        "owner",
+        "author",
+        "artworks_count",
+        "exhibits_count",
+        "uploaded_at",
+        "file_size",
+    ]
+    search_fields = ["title", "id"]
+    ordering = ["-uploaded_at"]
+
+    def get_queryset(self, request):
+        queryset = (
+            super()
+            .get_queryset(request)
+            .select_related("owner")
+            .prefetch_related("artworks", "artworks__exhibits")
+        )
+        queryset = queryset.annotate(
+            _artworks_count=Count("artworks", distinct=True),
+            _exhibits_count=Count("artworks__exhibits", distinct=True),
+        )
+        return queryset
+
+    def artworks_count(self, obj):
+        """Link to related Artworks"""
+        if obj.artworks_count == 0:
+            return obj._artworks_count
+        # Artwork IDs split by commas
+        artworks_list = obj.artworks_list.values_list("id", flat=True)
+        artworks_list = ",".join([str(i) for i in artworks_list])
+
+        link = reverse("admin:index") + "core/artwork/?id__in=" + str(artworks_list)
+        return format_html('<a href="{}">{}</a>', link, obj._artworks_count)
+
+    def exhibits_count(self, obj):
+        return obj._exhibits_count
+
+    def image_preview(self, obj):
+        return format_html(
+            '<img src="{}" style="height:200px; width:200px;"/>', obj.source.url
+        )
+
+    artworks_count.admin_order_field = "_artworks_count"
+    exhibits_count.admin_order_field = "_exhibits_count"

--- a/src/core/admin.py
+++ b/src/core/admin.py
@@ -9,6 +9,7 @@ from django.utils.html import format_html
 admin.site.register(Exhibit)
 admin.site.register(Artwork)
 
+
 def create_link_to_related_artworks(obj):
     """Link to related Artworks"""
     if obj.artworks_count == 0:
@@ -19,6 +20,7 @@ def create_link_to_related_artworks(obj):
 
     link = reverse("admin:index") + "core/artwork/?id__in=" + str(artworks_list)
     return format_html('<a href="{}">{}</a>', link, obj._artworks_count)
+
 
 @admin.register(Marker)
 class MarkerAdmin(admin.ModelAdmin):
@@ -65,18 +67,18 @@ class MarkerAdmin(admin.ModelAdmin):
         if obj.file_size > 0:
             return f"{obj.file_size / 1024 / 1024:.2f} MB"
         return obj.file_size
-    
 
     filesize.short_description = "File Size"
     filesize.admin_order_field = "file_size"
     artworks_count.admin_order_field = "_artworks_count"
     exhibits_count.admin_order_field = "_exhibits_count"
 
+
 @admin.register(Object)
 class ObjectAdmin(admin.ModelAdmin):
     list_display = [
         "title",
-        "image_preview",
+        "preview",
         "id",
         "owner",
         "author",
@@ -107,16 +109,26 @@ class ObjectAdmin(admin.ModelAdmin):
     def exhibits_count(self, obj):
         return obj._exhibits_count
 
-    def image_preview(self, obj):
+    def preview(self, obj):
         """Image preview with proportions"""
         max_height = 200
         max_width = 200
         height = max_height * obj.yproportion
         width = max_width * obj.xproportion
+        if obj.is_video:
+            return format_html(
+                '<video width="{}" height="{}" controls><source src="{}" type="video/mp4"></video>',
+                width,
+                height,
+                obj.source.url,
+            )
         return format_html(
-            '<img src="{}" style="height:{}px; width:{}px;"/>', obj.source.url, height, width
+            '<img src="{}" style="height:{}px; width:{}px;"/>',
+            obj.source.url,
+            height,
+            width,
         )
-    
+
     def filesize(self, obj):
         """File size in MB"""
         if obj.file_size > 0:

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -113,7 +113,6 @@ class Object(models.Model):
     def in_use(self):
         if self.artworks_count > 0 or self.exhibits_count > 0:
             return True
-
         return False
 
     @property
@@ -196,6 +195,15 @@ class Object(models.Model):
     def yposition(self):
         y = self.position.split(" ")[1]
         return float(y)
+
+    @property
+    def is_video(self):
+        """
+        checks if the Object is a video by checking the file extension.
+        """
+        if self.source.name.endswith(".mp4") or self.source.name.endswith(".webm"):
+            return True
+        return False
 
 
 class Artwork(models.Model):

--- a/src/users/admin.py
+++ b/src/users/admin.py
@@ -85,9 +85,6 @@ class ProfileAdmin(admin.ModelAdmin):
         )
         return queryset
 
-    def username(self, obj):
-        return obj.user.username
-
     def created(self, obj):
         return obj.user.date_joined
 

--- a/src/users/jinja2/users/components/elements-modal.jinja2
+++ b/src/users/jinja2/users/components/elements-modal.jinja2
@@ -33,7 +33,9 @@
                 artworks_count +  {{ _(" artworks")|tojson }} + '</a>' +
                 {{ _(" and in ")|tojson }} + '<a href="{{ url('related-content') }}?id=' + element_id + '&type=' + elemType + '">' + exhibits_count +
                 {{ _(" Exhibits")|tojson }} + '</a>' +
-                '<img id="element-src" src="' + element_src + '"/></p>'
+                ( element_src.endsWith('.mp4') || element_src.endsWith('.webm') ? 
+                    '<video muted autoplay loop id="element-src" class="preview-content" src="' + element_src + '"></video>' : 
+                    '<img id="element-src" class="preview-content" src="' + element_src + '"/>')
             )
         }
         function usedInExhibit(marker_id, object_id, exhibits_count, marker, augmented, element_id){

--- a/src/users/jinja2/users/components/item-list.jinja2
+++ b/src/users/jinja2/users/components/item-list.jinja2
@@ -31,7 +31,7 @@
 
                 {%set load_object_video_or_image %}
                     {% if element.source.url.split('.')[1] == "mp4" or element.source.url.split('.')[1] == "webm" %}
-                        <video id="{{ element.id }}" title="{{ element.title }}" class="trigger-modal" data-elem-type="{{element_type}}" src="{{ element.source.url }}" height="{{ element.yproportion * 50 }}" width="{{ element.xproportion * 50 }}" muted autoplay></video>
+                        <video id="{{ element.id }}" title="{{ element.title }}" class="trigger-modal" data-elem-type="{{element_type}}" src="{{ element.source.url }}" height="{{ element.yproportion * 50 }}" width="{{ element.xproportion * 50 }}" muted autoplay loop></video>
                     {% else %} 
                         {{loadImage_object_or_marker}}
                     {% endif %}
@@ -47,7 +47,7 @@
                 {%endset%}
 
                 {%set loadArtwork_Object%}
-                    {% if element.augmented.source.url.split('.')[1] == "mp4" or element.augmented.source.url.split('.')[1] == "webm" %}
+                    {% if element.augmented.source.url.endswith('.mp4') or element.augmented.source.url.endswith('.webm') %}
                         {% if element.title %}
                             <video id="{{ element.id }}" title="{{ element.title }}" class="trigger-modal" data-elem-type="{{element_type}}" src="{{ element.augmented.source.url }}" height="{{ element.augmented.yproportion * 50 }}" width="{{ element.augmented.xproportion * 50 }}" muted autoplay loop></video>
                         {% else %}


### PR DESCRIPTION
## Description

Improve Object and Markers django admin pages, enabling the analysis of usage by number of artworks and exhibits, while also including a preview of the respective content

## General tasks performed
* Created custom Object admin page
* Created custom Marker admin page
* Fixed video previews on collection and modal pages

### Have you confirmed the application builds locally without error? See [here](https://github.com/memeLab/Jandig#running).
- [x] Yes