### PR TITLE
Update Artwork and Exhibit admin pages

### DIFF
--- a/src/core/admin.py
+++ b/src/core/admin.py
@@ -143,3 +143,32 @@ class ArtworkAdmin(admin.ModelAdmin):
     augmented_preview.allow_tags = True
 
 
+@admin.register(Exhibit)
+class ExhibitAdmin(admin.ModelAdmin):
+    list_display = [
+        "name",
+        "slug",
+        "owner",
+        "artworks_count",
+        "creation_date",
+    ]
+    search_fields = ["name", "slug"]
+    ordering = ["-creation_date"]
+
+    def get_queryset(self, request):
+        queryset = (
+            super()
+            .get_queryset(request)
+            .select_related("owner")
+            .prefetch_related("artworks")
+        )
+        queryset = queryset.annotate(
+            _artworks_count=Count("artworks", distinct=True),
+        )
+        return queryset
+
+    def artworks_count(self, obj):
+        return create_link_to_related_artworks(obj, obj.artworks.all())
+    artworks_count.short_description = "Artworks Count"
+    artworks_count.admin_order_field = "_artworks_count"
+    artworks_count.allow_tags = True

--- a/src/core/admin.py
+++ b/src/core/admin.py
@@ -6,20 +6,39 @@ from core.models import Artwork, Exhibit, Marker, Object
 
 from django.utils.html import format_html
 
-admin.site.register(Exhibit)
-admin.site.register(Artwork)
-
-
-def create_link_to_related_artworks(obj):
+def create_link_to_related_artworks(obj, artworks_list):
     """Link to related Artworks"""
     if obj.artworks_count == 0:
         return obj._artworks_count
-    # Artwork IDs split by commas
-    artworks_list = obj.artworks_list.values_list("id", flat=True)
-    artworks_list = ",".join([str(i) for i in artworks_list])
+    artworks_list = ",".join([str(artwork.id) for artwork in artworks_list])
 
     link = reverse("admin:index") + "core/artwork/?id__in=" + str(artworks_list)
     return format_html('<a href="{}">{}</a>', link, obj._artworks_count)
+
+def format_marker_as_html(obj):
+    return format_html(
+            '<img src="{}" style="height:200px; width:200px;"/>', obj.source.url
+        )
+
+def format_object_as_html(obj):
+    """Image preview with proportions"""
+    max_height = 200
+    max_width = 200
+    height = max_height * obj.yproportion
+    width = max_width * obj.xproportion
+    if obj.is_video:
+        return format_html(
+            '<video width="{}" height="{}" controls><source src="{}" type="video/mp4"></video>',
+            width,
+            height,
+            obj.source.url,
+        )
+    return format_html(
+        '<img src="{}" style="height:{}px; width:{}px;"/>',
+        obj.source.url,
+        height,
+        width,
+    )
 
 
 class BaseMarkerObjectAdmin(admin.ModelAdmin):
@@ -51,8 +70,10 @@ class BaseMarkerObjectAdmin(admin.ModelAdmin):
         return queryset
 
     def artworks_count(self, obj):
-        return create_link_to_related_artworks(obj)
-
+        return create_link_to_related_artworks(obj, obj.artworks.all())
+    artworks_count.short_description = "Artworks Count"
+    artworks_count.allow_tags = True
+    
     def exhibits_count(self, obj):
         return obj._exhibits_count
 
@@ -71,29 +92,54 @@ class BaseMarkerObjectAdmin(admin.ModelAdmin):
 @admin.register(Marker)
 class MarkerAdmin(BaseMarkerObjectAdmin):
     def image_preview(self, obj):
-        return format_html(
-            '<img src="{}" style="height:200px; width:200px;"/>', obj.source.url
-        )
+        return format_marker_as_html(obj)
 
 
 @admin.register(Object)
 class ObjectAdmin(BaseMarkerObjectAdmin):
     def image_preview(self, obj):
-        """Image preview with proportions"""
-        max_height = 200
-        max_width = 200
-        height = max_height * obj.yproportion
-        width = max_width * obj.xproportion
-        if obj.is_video:
-            return format_html(
-                '<video width="{}" height="{}" controls><source src="{}" type="video/mp4"></video>',
-                width,
-                height,
-                obj.source.url,
-            )
-        return format_html(
-            '<img src="{}" style="height:{}px; width:{}px;"/>',
-            obj.source.url,
-            height,
-            width,
+        return format_object_as_html(obj)
+
+@admin.register(Artwork)
+class ArtworkAdmin(admin.ModelAdmin):
+    list_display = [
+        "title",
+        "id",
+        "author",
+        "marker_preview",
+        "augmented_preview",
+        "exhibits_count",
+        "created_at",
+    ]
+    search_fields = ["title", "id"]
+    ordering = ["-created_at"]
+
+    def get_queryset(self, request):
+        queryset = (
+            super()
+            .get_queryset(request)
+            .select_related("author", "marker", "augmented")
+            .prefetch_related("exhibits")
         )
+        queryset = queryset.annotate(
+            _exhibits_count=Count("exhibits", distinct=True),
+        )
+        return queryset
+
+    def exhibits_count(self, obj):
+        return obj._exhibits_count
+    
+    exhibits_count.admin_order_field = "_exhibits_count"
+    exhibits_count.short_description = "Exhibits Count"
+
+    def marker_preview(self, obj):
+        return format_marker_as_html(obj.marker)
+    marker_preview.short_description = "Marker"
+    marker_preview.allow_tags = True
+
+    def augmented_preview(self, obj):
+        return format_object_as_html(obj.augmented)
+    augmented_preview.short_description = "Augmented Object"
+    augmented_preview.allow_tags = True
+
+

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -238,6 +238,7 @@ class Artwork(models.Model):
     def __str__(self):
         return self.title
 
+
 @receiver(post_delete, sender=Object)
 @receiver(post_delete, sender=Marker)
 def remove_source_file(sender, instance, **kwargs):

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -235,6 +235,8 @@ class Artwork(models.Model):
 
         return False
 
+    def __str__(self):
+        return self.title
 
 @receiver(post_delete, sender=Object)
 @receiver(post_delete, sender=Marker)

--- a/src/core/tests/test_bot_protection.py
+++ b/src/core/tests/test_bot_protection.py
@@ -27,7 +27,6 @@ class TestInvalidIndex(TestCase):
         response = self.client.get("/exhibit/")
         self.assertEqual(response.status_code, 404)
 
-
     def test_invalid_exhibit_slug(self):
         # Test invalid exhibit
         response = self.client.get("/invalid")

--- a/src/core/tests/test_bot_protection.py
+++ b/src/core/tests/test_bot_protection.py
@@ -18,6 +18,16 @@ class TestInvalidIndex(TestCase):
         response = self.client.get("/exhibit/?id='999'")
         self.assertEqual(response.status_code, 404)
 
+    def test_empty_exhibit_id(self):
+        # Test empty exhibit id should not raise exception and return 404
+        response = self.client.get("/exhibit/?id=''")
+        self.assertEqual(response.status_code, 404)
+        response = self.client.get("/exhibit/?id=")
+        self.assertEqual(response.status_code, 404)
+        response = self.client.get("/exhibit/")
+        self.assertEqual(response.status_code, 404)
+
+
     def test_invalid_exhibit_slug(self):
         # Test invalid exhibit
         response = self.client.get("/invalid")

--- a/src/core/views/views.py
+++ b/src/core/views/views.py
@@ -103,7 +103,7 @@ def exhibit_select(request):
 @cache_page(60 * 60)
 @require_http_methods(["GET"])
 def exhibit_detail(request):
-    index = request.GET.get("id")
+    index = request.GET.get("id", -1)
     # Bots insert random strings in the id parameter, index should be an integer
     try:
         index = int(index)

--- a/src/core/views/views.py
+++ b/src/core/views/views.py
@@ -33,8 +33,8 @@ def index(request):
 @cache_page(60 * 2)
 @require_http_methods(["GET"])
 def collection(request):
-    exhibits = Exhibit.objects.all().order_by("creation_date")[:4]
-    artworks = Artwork.objects.all().order_by("created_at")[:6]
+    exhibits = Exhibit.objects.prefetch_related("artworks").all().order_by("creation_date")[:4]
+    artworks = Artwork.objects.prefetch_related("marker","augmented").all().order_by("created_at")[:6]
     markers = Marker.objects.all().order_by("uploaded_at")[:8]
     objects = Object.objects.all().order_by("uploaded_at")[:8]
 
@@ -70,8 +70,8 @@ def see_all(request, which="", page=1):
     data_types = {
         "objects": Object.objects.all().order_by("uploaded_at"),
         "markers": Marker.objects.all().order_by("uploaded_at"),
-        "artworks": Artwork.objects.all().order_by("created_at"),
-        "exhibits": Exhibit.objects.all().order_by("creation_date"),
+        "artworks": Artwork.objects.prefetch_related("marker","augmented").all().order_by("created_at"),
+        "exhibits": Exhibit.objects.prefetch_related("artworks").all().order_by("creation_date"),
     }
 
     data = data_types.get(request_type)

--- a/src/core/views/views.py
+++ b/src/core/views/views.py
@@ -33,8 +33,14 @@ def index(request):
 @cache_page(60 * 2)
 @require_http_methods(["GET"])
 def collection(request):
-    exhibits = Exhibit.objects.prefetch_related("artworks").all().order_by("creation_date")[:4]
-    artworks = Artwork.objects.prefetch_related("marker","augmented").all().order_by("created_at")[:6]
+    exhibits = (
+        Exhibit.objects.prefetch_related("artworks").all().order_by("creation_date")[:4]
+    )
+    artworks = (
+        Artwork.objects.prefetch_related("marker", "augmented")
+        .all()
+        .order_by("created_at")[:6]
+    )
     markers = Marker.objects.all().order_by("uploaded_at")[:8]
     objects = Object.objects.all().order_by("uploaded_at")[:8]
 
@@ -70,8 +76,12 @@ def see_all(request, which="", page=1):
     data_types = {
         "objects": Object.objects.all().order_by("uploaded_at"),
         "markers": Marker.objects.all().order_by("uploaded_at"),
-        "artworks": Artwork.objects.prefetch_related("marker","augmented").all().order_by("created_at"),
-        "exhibits": Exhibit.objects.prefetch_related("artworks").all().order_by("creation_date"),
+        "artworks": Artwork.objects.prefetch_related("marker", "augmented")
+        .all()
+        .order_by("created_at"),
+        "exhibits": Exhibit.objects.prefetch_related("artworks")
+        .all()
+        .order_by("creation_date"),
     }
 
     data = data_types.get(request_type)

--- a/src/users/models.py
+++ b/src/users/models.py
@@ -13,7 +13,7 @@ class Profile(models.Model):
     personal_site = models.URLField()
 
     def __str__(self):
-        return str(self.user)
+        return self.user.username
 
     class Meta:
         permissions = [

--- a/src/users/views.py
+++ b/src/users/views.py
@@ -184,7 +184,7 @@ def create_artwork(request):
                     title=artwork_title,
                     description=artwork_desc,
                 ).save()
-            return redirect("home")
+            return redirect("profile")
     else:
         form = ArtworkForm()
 
@@ -218,7 +218,7 @@ def create_exhibit(request):
             exhibit.save()
             exhibit.artworks.set(artworks)
 
-            return redirect("home")
+            return redirect("profile")
     else:
         form = ExhibitForm()
 
@@ -241,7 +241,7 @@ def upload_elements(request, form_class, form_type, route):
             upload = form.save(commit=False)
             upload.owner = request.user.profile
             upload.save()
-            return redirect("home")
+            return redirect("profile")
     else:
         form = form_class()
 


### PR DESCRIPTION
## Description

Updated the artwork and exhibit admin pages, for easier visualization and analysis of data.

## General tasks performed
* Fixed N+1 queries on Collection and See All pages
* Created new Artwork admin page
* Created new Exhibit admin page
* Improved performance on all core admin pages

### Have you confirmed the application builds locally without error? See [here](https://github.com/memeLab/Jandig#running).
- [x] Yes