### PR TITLE
Enable search in exhibit api

### DIFF
--- a/.github/workflows/PipelineRC.yml
+++ b/.github/workflows/PipelineRC.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           export UV_PROJECT_ENVIRONMENT="${pythonLocation}"
           uv sync --only-dev
+          export ROOT_DIR=${GITHUB_WORKSPACE}/
           uv run pytest src/core src/users/ src/blog --cov=src --cov-report=xml
 
       - name: Upload coverage report

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,12 @@ test-all:
 	docker compose exec django uv run pytest
 
 lint:
-	uv run ruff format src
-	uv run ruff check --select I --fix src
+	@if [[ -n "${RUNNING_CONTAINER}" ]]; then \
+		docker compose exec django bash -c "uv run ruff format src && uv run ruff check --select I --fix src"; \
+	else \
+		docker compose run django bash -c "uv run ruff format src && uv run ruff check --select I --fix src"; \
+	fi
+
 
 check: 
 	uv run ruff check

--- a/etc/haproxy/haproxy.cfg
+++ b/etc/haproxy/haproxy.cfg
@@ -19,7 +19,7 @@ frontend http_front
 
 backend django
     mode http
-    server django_server django:8000
+    server django_server django:8000 check disabled  # Disable health checks
 
 backend storage
     mode http

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Jandig"
-version = "1.4.3"
+version = "1.4.4"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -45,7 +45,7 @@ ENABLE_SENTRY = env("ENABLE_SENTRY", default=False)
 HEALTH_CHECK_URL = env("HEALTH_CHECK_URL", default="api/v1/status/")
 SENTRY_TRACES_SAMPLE_RATE = env("SENTRY_TRACES_SAMPLE_RATE", default=0.1)
 SENTRY_ENVIRONMENT = env("SENTRY_ENVIRONMENT", default="")
-SENTRY_RELEASE = env("SENTRY_RELEASE", default="1.4.3")
+SENTRY_RELEASE = env("SENTRY_RELEASE", default="1.4.4")
 
 
 def traces_sampler(sampling_context):

--- a/src/config/test_settings.py
+++ b/src/config/test_settings.py
@@ -20,3 +20,5 @@ DATABASES = {
         "NAME": ":memory:",
     }
 }
+
+ROOT_DIR = env("ROOT_DIR", default="/jandig/")

--- a/src/core/tests/factory.py
+++ b/src/core/tests/factory.py
@@ -124,6 +124,7 @@ class ArtworkFactory(DjangoModelFactory):
 class ExhibitFactory(DjangoModelFactory):
     class Meta:
         model = Exhibit
+        skip_postgeneration_save = True
 
     owner = SubFactory(ProfileFactory)  # Use ProfileFactory for the owner
     name = Faker("sentence", nb_words=3)  # Generate a random unique name

--- a/src/core/tests/test_exhibits_api.py
+++ b/src/core/tests/test_exhibits_api.py
@@ -8,15 +8,15 @@ from core.models import Artwork, Exhibit, Marker, Object
 from core.serializers import ArtworkSerializer
 from core.tests.factory import ExhibitFactory
 from users.models import User
-from users.tests.factory import ProfileFactory
+from users.tests.factory import ProfileFactory, UserFactory
 
 fake_file = SimpleUploadedFile("fake_file.png", b"these are the file contents!")
 
 
 class TestExhibitAPI(TestCase):
     def setUp(self):
-        self.user = User.objects.create()
-        self.profile = self.user.profile
+        self.user = UserFactory(username="testuserexhibit")
+        self.profile = ProfileFactory(user=self.user)
 
     def test_url(self):
         """Test that the root page of the api exists"""
@@ -30,27 +30,32 @@ class TestExhibitAPI(TestCase):
 
     def test_api_exhibits_lists_one_exhibit(self):
         """API returns one exhibit if there is one exhibit"""
-        marker = Marker.objects.create(owner=self.profile, source=fake_file)
-        obj = Object.objects.create(owner=self.profile, source=fake_file)
-        artwork = Artwork.objects.create(
-            author=self.profile, augmented=obj, marker=marker
-        )
-        exhibit = Exhibit.objects.create(owner=self.profile, name="test")
-        exhibit.artworks.add(artwork)
-        response = self.client.get("/api/v1/artworks/")
+        exhibit = ExhibitFactory(owner=self.profile, name="test")
+        response = self.client.get("/api/v1/exhibits/")
         self.assertEqual(response.status_code, 200)
+        data = response.json()
+        assert data["count"] == 1
+        assert data["results"][0]["id"] == exhibit.id
+        assert data["results"][0]["name"] == exhibit.name
+        assert data["results"][0]["slug"] == exhibit.slug
+        assert data["results"][0]["owner"] == self.profile.id
+        assert (
+            data["results"][0]["artworks"]
+            == ArtworkSerializer(exhibit.artworks.all(), many=True).data
+        )
 
     def test_api_exhibit_lists_multiple_exhibits(self):
         """API returns multiple exhibits if there are multiple exhibits"""
         for i in range(0, settings.PAGE_SIZE + 1):
-            marker = Marker.objects.create(owner=self.profile, source=fake_file)
-            obj = Object.objects.create(owner=self.profile, source=fake_file)
-            Artwork.objects.create(author=self.profile, augmented=obj, marker=marker)
-            Exhibit.objects.create(
-                owner=self.profile, name=f"name_{i}", slug=f"slug_{i}"
-            )
+            ExhibitFactory(owner=self.profile, name=f"name_{i}", slug=f"slug_{i}")
         response = self.client.get("/api/v1/exhibits/")
         self.assertEqual(response.status_code, 200)
+        data = response.json()
+        assert data["count"] == settings.PAGE_SIZE + 1
+        assert (
+            data["next"]
+            == f"http://testserver/api/v1/exhibits/?limit={settings.PAGE_SIZE}&offset={settings.PAGE_SIZE}"
+        )
 
     def test_retrieve_exhibit(self):
         """Test that the exhibit can be retrieved using its ID on the API path"""
@@ -66,20 +71,19 @@ class TestExhibitAPI(TestCase):
 
     def test_searching_exhibits(self):
         """Test that the exhibit can be searched using owner id"""
-        user = ProfileFactory()
-        exhibit = ExhibitFactory(owner=user)
+        exhibit = ExhibitFactory(owner=self.profile)
 
         # Extra exhibit from another owner to check if it is not included
         _ = ExhibitFactory()
 
-        response = self.client.get(f"/api/v1/exhibits/?owner={user.id}")
+        response = self.client.get(f"/api/v1/exhibits/?owner={self.profile.user.id}")
         self.assertEqual(response.status_code, 200)
         data = response.json()
         assert data["count"] == 1
         assert data["results"][0]["id"] == exhibit.id
         assert data["results"][0]["name"] == exhibit.name
         assert data["results"][0]["slug"] == exhibit.slug
-        assert data["results"][0]["owner"] == user.id
+        assert data["results"][0]["owner"] == self.profile.user.id
         assert (
             data["results"][0]["artworks"]
             == ArtworkSerializer(exhibit.artworks.all(), many=True).data

--- a/src/core/tests/test_exhibits_api.py
+++ b/src/core/tests/test_exhibits_api.py
@@ -5,7 +5,10 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 
 from core.models import Artwork, Exhibit, Marker, Object
+from core.serializers import ArtworkSerializer
+from core.tests.factory import ExhibitFactory
 from users.models import User
+from users.tests.factory import ProfileFactory
 
 fake_file = SimpleUploadedFile("fake_file.png", b"these are the file contents!")
 
@@ -16,6 +19,7 @@ class TestExhibitAPI(TestCase):
         self.profile = self.user.profile
 
     def test_url(self):
+        """Test that the root page of the api exists"""
         response = self.client.get("/api/v1/exhibits/")
         self.assertEqual(response.status_code, 200)
         data = response.json()
@@ -25,6 +29,7 @@ class TestExhibitAPI(TestCase):
         self.assertEqual(data["results"], [])
 
     def test_api_exhibits_lists_one_exhibit(self):
+        """API returns one exhibit if there is one exhibit"""
         marker = Marker.objects.create(owner=self.profile, source=fake_file)
         obj = Object.objects.create(owner=self.profile, source=fake_file)
         artwork = Artwork.objects.create(
@@ -36,6 +41,7 @@ class TestExhibitAPI(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_api_exhibit_lists_multiple_exhibits(self):
+        """API returns multiple exhibits if there are multiple exhibits"""
         for i in range(0, settings.PAGE_SIZE + 1):
             marker = Marker.objects.create(owner=self.profile, source=fake_file)
             obj = Object.objects.create(owner=self.profile, source=fake_file)
@@ -47,6 +53,7 @@ class TestExhibitAPI(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_retrieve_exhibit(self):
+        """Test that the exhibit can be retrieved using its ID on the API path"""
         marker = Marker.objects.create(owner=self.profile, source=fake_file)
         obj = Object.objects.create(owner=self.profile, source=fake_file)
         artwork = Artwork.objects.create(
@@ -56,3 +63,50 @@ class TestExhibitAPI(TestCase):
         exhibit.artworks.add(artwork)
         response = self.client.get(f"/api/v1/exhibits/{str(exhibit.id)}/")
         self.assertEqual(response.status_code, 200)
+
+    def test_searching_exhibits(self):
+        """Test that the exhibit can be searched using owner id"""
+        user = ProfileFactory()
+        exhibit = ExhibitFactory(owner=user)
+
+        # Extra exhibit from another owner to check if it is not included
+        _ = ExhibitFactory()
+
+        response = self.client.get(f"/api/v1/exhibits/?owner={user.id}")
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        assert data["count"] == 1
+        assert data["results"][0]["id"] == exhibit.id
+        assert data["results"][0]["name"] == exhibit.name
+        assert data["results"][0]["slug"] == exhibit.slug
+        assert data["results"][0]["owner"] == user.id
+        assert (
+            data["results"][0]["artworks"]
+            == ArtworkSerializer(exhibit.artworks.all(), many=True).data
+        )
+
+    def test_searching_exhibits_by_invalid_owner(self):
+        """Test that the exhibit cannot be searched using invalid owner id"""
+        user = ProfileFactory()
+        exhibit = ExhibitFactory(owner=user)
+
+        # Extra exhibit from another owner to check if it is not included
+        _ = ExhibitFactory()
+
+        response = self.client.get(f"/api/v1/exhibits/?owner=99999")
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        assert data["count"] == 0
+        assert data["results"] == []
+
+        response = self.client.get(f"/api/v1/exhibits/?owner=invalid")
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        assert data["count"] == 0
+        assert data["results"] == []
+
+        response = self.client.get(f"/api/v1/exhibits/?owner=")
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        assert data["count"] == 0
+        assert data["results"] == []

--- a/src/core/views/viewsets.py
+++ b/src/core/views/viewsets.py
@@ -66,7 +66,9 @@ class ExhibitViewset(ListModelMixin, RetrieveModelMixin, GenericViewSet):
             .order_by("id")
         )
         owner_id = self.request.query_params.get("owner")
-
+        search = self.request.query_params.get("search")
+        if search:
+            queryset = queryset.filter(name__icontains=search)
         if owner_id is not None:
             try:
                 owner_id = int(owner_id)

--- a/src/core/views/viewsets.py
+++ b/src/core/views/viewsets.py
@@ -11,38 +11,6 @@ from core.serializers import (
 )
 
 
-class ArtworkViewset(ListModelMixin, RetrieveModelMixin, GenericViewSet):
-    serializer_class = ArtworkSerializer
-    queryset = (
-        Artwork.objects.prefetch_related(
-            "exhibits", "marker__artworks", "augmented__artworks"
-        )
-        .select_related(
-            "author__user",
-            "marker__owner__user",
-            "augmented__owner__user",
-        )
-        .all()
-        .order_by("id")
-    )
-
-
-class ExhibitViewset(ListModelMixin, RetrieveModelMixin, GenericViewSet):
-    serializer_class = ExhibitSerializer
-    queryset = (
-        Exhibit.objects.prefetch_related(
-            "artworks__exhibits",
-            "artworks__author__user",
-            "artworks__marker__artworks",
-            "artworks__marker__owner__user",
-            "artworks__augmented__artworks",
-            "artworks__augmented__owner__user",
-        )
-        .all()
-        .order_by("id")
-    )
-
-
 class MarkerViewset(ListModelMixin, RetrieveModelMixin, GenericViewSet):
     serializer_class = MarkerSerializer
     queryset = (
@@ -63,3 +31,47 @@ class ObjectViewset(ListModelMixin, RetrieveModelMixin, GenericViewSet):
         .all()
         .order_by("id")
     )
+
+
+class ArtworkViewset(ListModelMixin, RetrieveModelMixin, GenericViewSet):
+    serializer_class = ArtworkSerializer
+    queryset = (
+        Artwork.objects.prefetch_related(
+            "exhibits", "marker__artworks", "augmented__artworks"
+        )
+        .select_related(
+            "author__user",
+            "marker__owner__user",
+            "augmented__owner__user",
+        )
+        .all()
+        .order_by("id")
+    )
+
+
+class ExhibitViewset(ListModelMixin, RetrieveModelMixin, GenericViewSet):
+    serializer_class = ExhibitSerializer
+
+    def get_queryset(self):
+        queryset = (
+            Exhibit.objects.prefetch_related(
+                "artworks__exhibits",
+                "artworks__author__user",
+                "artworks__marker__artworks",
+                "artworks__marker__owner__user",
+                "artworks__augmented__artworks",
+                "artworks__augmented__owner__user",
+            )
+            .all()
+            .order_by("id")
+        )
+        owner_id = self.request.query_params.get("owner")
+
+        if owner_id is not None:
+            try:
+                owner_id = int(owner_id)
+            except ValueError:
+                # Handle the case where owner_id is not a valid integer
+                return queryset.none()
+            queryset = queryset.filter(owner=owner_id)
+        return queryset

--- a/src/users/admin.py
+++ b/src/users/admin.py
@@ -77,12 +77,6 @@ class ProfileAdmin(admin.ModelAdmin):
             .select_related("user")
             .prefetch_related("artworks", "markers", "exhibits", "ar_objects")
         )
-        queryset = queryset.annotate(
-            _markers_count=Count("markers", distinct=True),
-            _artworks_count=Count("artworks", distinct=True),
-            _ar_objects_count=Count("ar_objects", distinct=True),
-            _exhibits_count=Count("exhibits", distinct=True),
-        )
         return queryset
 
     def created(self, obj):
@@ -95,23 +89,6 @@ class ProfileAdmin(admin.ModelAdmin):
         """Link to related User"""
         link = reverse("admin:index") + "auth/user/?id=" + str(obj.user.id)
         return format_html('<a href="{}">{}</a>', link, obj.user.username)
-
-    def artworks_count(self, obj):
-        return obj._artworks_count
-
-    def markers_count(self, obj):
-        return obj._markers_count
-
-    def ar_objects_count(self, obj):
-        return obj._ar_objects_count
-
-    def exhibits_count(self, obj):
-        return obj._exhibits_count
-
-    artworks_count.admin_order_field = "_artworks_count"
-    markers_count.admin_order_field = "_markers_count"
-    ar_objects_count.admin_order_field = "_ar_objects_count"
-    exhibits_count.admin_order_field = "_exhibits_count"
 
 
 @admin.register(User)

--- a/src/users/models.py
+++ b/src/users/models.py
@@ -20,6 +20,26 @@ class Profile(models.Model):
             ("moderator", "Can moderate content"),
         ]
 
+    @property
+    def artworks_count(self):
+        """Count of artworks by the user"""
+        return self.artworks.count()
+
+    @property
+    def markers_count(self):
+        """Count of markers by the user"""
+        return self.markers.count()
+
+    @property
+    def ar_objects_count(self):
+        """Count of AR objects by the user"""
+        return self.ar_objects.count()
+
+    @property
+    def exhibits_count(self):
+        """Count of exhibits by the user"""
+        return self.exhibits.count()
+
 
 @receiver(post_save, sender=User)
 def create_user_profile(sender, instance, created, **kwargs):

--- a/src/users/tests/factory.py
+++ b/src/users/tests/factory.py
@@ -1,14 +1,25 @@
 from django.contrib.auth.models import User
 from django.db.models.signals import post_save
-from factory import Faker, SubFactory, django
+from factory import Faker, Sequence, SubFactory, django
 from factory.django import DjangoModelFactory
 
 from users.models import Profile
 
 
+def generate_username():
+    """
+    Generates a random username using the Faker library.
+    """
+    prefix = Faker("prefix").evaluate(None, 0, {"locale": "en-US"})
+    first_name = Faker("first_name").evaluate(None, 0, {"locale": "en-US"})
+    last_name = Faker("last_name").evaluate(None, 0, {"locale": "en-US"})
+    suffix = Faker("suffix").evaluate(None, 0, {"locale": "en-US"})
+    return f"{prefix.lower()}{first_name.lower()}{last_name.lower()}{suffix.lower()}"
+
+
 @django.mute_signals(post_save)
 class UserFactory(DjangoModelFactory):
-    username = Faker("user_name")
+    username = Sequence(lambda n: f"{generate_username()}_{n}")
     email = Faker("email")
 
     class Meta:


### PR DESCRIPTION
## Description

Enable searching in the Exhibit API by User ID or Name, using query parameters "search" or "owner".

`/api/v1/exhibits/?owner=2`
`/api/v1/exhibits/?search=longa vida`
`/api/v1/exhibits/?owner=1&search=teste`

### Have you confirmed the application builds locally without error? See [here](https://github.com/memeLab/Jandig#running).
- [x] Yes