### PR TITLE
Add API for user logins with simple jwt

### DIFF
--- a/.github/workflows/Linter.yml
+++ b/.github/workflows/Linter.yml
@@ -32,7 +32,7 @@ jobs:
       
         run: |
           export UV_PROJECT_ENVIRONMENT="${pythonLocation}"
-          uv run ruff check --select I --output-format=github
+          uv run ruff check --extend-select I --output-format=github
       
       - name: Check Ruff Formatting
         run : |

--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,9 @@ test-all:
 
 lint:
 	@if [[ -n "${RUNNING_CONTAINER}" ]]; then \
-		docker compose exec django bash -c "uv run ruff format src && uv run ruff check --select I --fix src"; \
+		docker compose exec django bash -c "uv run ruff format src && uv run ruff check --extend-select I --fix src"; \
 	else \
-		docker compose run django bash -c "uv run ruff format src && uv run ruff check --select I --fix src"; \
+		docker compose run django bash -c "uv run ruff format src && uv run ruff check --extend-select I --fix src"; \
 	fi
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ dependencies = [
   "pymarker~=0.3",
   "sentry-sdk[django]~=2.20",
   "Sphinx~=8.1",
+  "dj-rest-auth>=7.0.1",
+  "djangorestframework-simplejwt>=5.5.0",
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Jandig"
-version = "1.4.4"
+version = "1.5.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -25,7 +25,6 @@ dependencies = [
   "pymarker~=0.3",
   "sentry-sdk[django]~=2.20",
   "Sphinx~=8.1",
-  "dj-rest-auth>=7.0.1",
   "djangorestframework-simplejwt>=5.5.0",
 ]
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 import sys
+from datetime import timedelta
 from socket import gethostbyname, gethostname
 
 import environ
@@ -45,7 +46,7 @@ ENABLE_SENTRY = env("ENABLE_SENTRY", default=False)
 HEALTH_CHECK_URL = env("HEALTH_CHECK_URL", default="api/v1/status/")
 SENTRY_TRACES_SAMPLE_RATE = env("SENTRY_TRACES_SAMPLE_RATE", default=0.1)
 SENTRY_ENVIRONMENT = env("SENTRY_ENVIRONMENT", default="")
-SENTRY_RELEASE = env("SENTRY_RELEASE", default="1.4.4")
+SENTRY_RELEASE = env("SENTRY_RELEASE", default="1.5.0")
 
 
 def traces_sampler(sampling_context):
@@ -78,9 +79,9 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django_extensions",
-    "dj_rest_auth",
     "rest_framework",
     "rest_framework.authtoken",
+    "rest_framework_simplejwt",
     "debug_toolbar",
     "django_htmx",
     "corsheaders",
@@ -120,15 +121,14 @@ REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
     "PAGE_SIZE": PAGE_SIZE,
     "DEFAULT_AUTHENTICATION_CLASSES": [
-        "dj_rest_auth.jwt_auth.JWTCookieAuthentication",
+        "rest_framework_simplejwt.authentication.JWTAuthentication",
     ],
 }
-REST_AUTH = {
-    "USE_JWT": True,
-    "JWT_AUTH_COOKIE": "jandig-auth",
-    "JWT_AUTH_REFRESH_COOKIE": "jandig-refresh-token",
+SIMPLE_JWT = {
+    "ACCESS_TOKEN_LIFETIME": timedelta(minutes=5),
+    "REFRESH_TOKEN_LIFETIME": timedelta(days=1),
+    "TOKEN_OBTAIN_SERIALIZER": "users.serializers.JandigJWTSerializer",
 }
-
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.jinja2.Jinja2",

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -70,7 +70,6 @@ if ENABLE_SENTRY:
         release=SENTRY_RELEASE,
     )
 
-
 INSTALLED_APPS = [
     "django.contrib.admin",
     "django.contrib.auth",
@@ -79,7 +78,9 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django_extensions",
+    "dj_rest_auth",
     "rest_framework",
+    "rest_framework.authtoken",
     "debug_toolbar",
     "django_htmx",
     "corsheaders",
@@ -118,6 +119,14 @@ REST_FRAMEWORK = {
     ],
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
     "PAGE_SIZE": PAGE_SIZE,
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "dj_rest_auth.jwt_auth.JWTCookieAuthentication",
+    ],
+}
+REST_AUTH = {
+    "USE_JWT": True,
+    "JWT_AUTH_COOKIE": "jandig-auth",
+    "JWT_AUTH_REFRESH_COOKIE": "jandig-refresh-token",
 }
 
 TEMPLATES = [

--- a/src/config/test_settings.py
+++ b/src/config/test_settings.py
@@ -1,5 +1,8 @@
 from config.settings import *  # noqa F403 F401
 
+import environ
+
+env = environ.Env()
 
 STORAGES = {
     "default": {

--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -29,7 +29,7 @@ urlpatterns = [
     path("api/v1/auth/login/", LoginView.as_view(), name="login"),
     path("api/v1/auth/logout/", LogoutView.as_view(), name="logout"),
     path("api/v1/auth/verify/", TokenVerifyView.as_view(), name="verify"),
-    path("api/v1/auth/refresh/", get_refresh_view(), name="refresh"),
+    path("api/v1/auth/refresh/", get_refresh_view().as_view(), name="refresh"),
     path("users/", include("users.urls")),
     path("memories/", include("blog.urls")),
     re_path("^docs/(?P<path>.*)$", serve, {"document_root": settings.DOCS_ROOT}),

--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -14,11 +14,14 @@ from core.views.viewsets import (
     MarkerViewset,
     ObjectViewset,
 )
+from users.viewsets import ProfileViewset
+
 api_router = DefaultRouter()
 api_router.register("markers", MarkerViewset, basename="marker")
 api_router.register("objects", ObjectViewset, basename="object")
 api_router.register("artworks", ArtworkViewset, basename="artwork")
 api_router.register("exhibits", ExhibitViewset, basename="exhibit")
+api_router.register("profiles", ProfileViewset, basename="profile")
 
 urlpatterns = [
     path(settings.DJANGO_ADMIN_URL, admin.site.urls),

--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -3,9 +3,23 @@ from django.conf import settings
 from django.conf.urls.static import serve
 from django.contrib import admin
 from django.urls import include, path, re_path
+from rest_framework_nested.routers import DefaultRouter
+
+from core.views.viewsets import (
+    ArtworkViewset,
+    ExhibitViewset,
+    MarkerViewset,
+    ObjectViewset,
+)
+api_router = DefaultRouter()
+api_router.register("markers", MarkerViewset, basename="marker")
+api_router.register("objects", ObjectViewset, basename="object")
+api_router.register("artworks", ArtworkViewset, basename="artwork")
+api_router.register("exhibits", ExhibitViewset, basename="exhibit")
 
 urlpatterns = [
     path(settings.DJANGO_ADMIN_URL, admin.site.urls),
+    path("api/v1/", include(api_router.urls)),
     path("users/", include("users.urls")),
     path("memories/", include("blog.urls")),
     re_path("^docs/(?P<path>.*)$", serve, {"document_root": settings.DOCS_ROOT}),

--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -1,12 +1,14 @@
 import debug_toolbar
-from dj_rest_auth.jwt_auth import get_refresh_view
-from dj_rest_auth.views import LoginView, LogoutView
 from django.conf import settings
 from django.conf.urls.static import serve
 from django.contrib import admin
 from django.urls import include, path, re_path
 from rest_framework_nested.routers import DefaultRouter
-from rest_framework_simplejwt.views import TokenVerifyView
+from rest_framework_simplejwt.views import (
+    TokenObtainPairView,
+    TokenRefreshView,
+    TokenVerifyView,
+)
 
 from core.views.viewsets import (
     ArtworkViewset,
@@ -26,10 +28,9 @@ api_router.register("profiles", ProfileViewset, basename="profile")
 urlpatterns = [
     path(settings.DJANGO_ADMIN_URL, admin.site.urls),
     path("api/v1/", include(api_router.urls)),
-    path("api/v1/auth/login/", LoginView.as_view(), name="login"),
-    path("api/v1/auth/logout/", LogoutView.as_view(), name="logout"),
+    path("api/v1/auth/login/", TokenObtainPairView.as_view(), name="login"),
     path("api/v1/auth/verify/", TokenVerifyView.as_view(), name="verify"),
-    path("api/v1/auth/refresh/", get_refresh_view().as_view(), name="refresh"),
+    path("api/v1/auth/refresh/", TokenRefreshView().as_view(), name="refresh"),
     path("users/", include("users.urls")),
     path("memories/", include("blog.urls")),
     re_path("^docs/(?P<path>.*)$", serve, {"document_root": settings.DOCS_ROOT}),

--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -1,9 +1,12 @@
 import debug_toolbar
+from dj_rest_auth.jwt_auth import get_refresh_view
+from dj_rest_auth.views import LoginView, LogoutView
 from django.conf import settings
 from django.conf.urls.static import serve
 from django.contrib import admin
 from django.urls import include, path, re_path
 from rest_framework_nested.routers import DefaultRouter
+from rest_framework_simplejwt.views import TokenVerifyView
 
 from core.views.viewsets import (
     ArtworkViewset,
@@ -20,6 +23,10 @@ api_router.register("exhibits", ExhibitViewset, basename="exhibit")
 urlpatterns = [
     path(settings.DJANGO_ADMIN_URL, admin.site.urls),
     path("api/v1/", include(api_router.urls)),
+    path("api/v1/auth/login/", LoginView.as_view(), name="login"),
+    path("api/v1/auth/logout/", LogoutView.as_view(), name="logout"),
+    path("api/v1/auth/verify/", TokenVerifyView.as_view(), name="verify"),
+    path("api/v1/auth/refresh/", get_refresh_view(), name="refresh"),
     path("users/", include("users.urls")),
     path("memories/", include("blog.urls")),
     re_path("^docs/(?P<path>.*)$", serve, {"document_root": settings.DOCS_ROOT}),

--- a/src/core/tests/test_exhibits_api.py
+++ b/src/core/tests/test_exhibits_api.py
@@ -4,10 +4,8 @@ from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 
-from core.models import Artwork, Exhibit, Marker, Object
 from core.serializers import ArtworkSerializer
 from core.tests.factory import ExhibitFactory
-from users.models import User
 from users.tests.factory import ProfileFactory, UserFactory
 
 fake_file = SimpleUploadedFile("fake_file.png", b"these are the file contents!")
@@ -95,19 +93,19 @@ class TestExhibitAPI(TestCase):
     def test_searching_exhibits_by_invalid_owner(self):
         """Test that the exhibit cannot be searched using invalid owner id"""
 
-        response = self.client.get(f"/api/v1/exhibits/?owner=99999")
+        response = self.client.get("/api/v1/exhibits/?owner=99999")
         self.assertEqual(response.status_code, 200)
         data = response.json()
         assert data["count"] == 0
         assert data["results"] == []
 
-        response = self.client.get(f"/api/v1/exhibits/?owner=invalid")
+        response = self.client.get("/api/v1/exhibits/?owner=invalid")
         self.assertEqual(response.status_code, 200)
         data = response.json()
         assert data["count"] == 0
         assert data["results"] == []
 
-        response = self.client.get(f"/api/v1/exhibits/?owner=")
+        response = self.client.get("/api/v1/exhibits/?owner=")
         self.assertEqual(response.status_code, 200)
         data = response.json()
         assert data["count"] == 0
@@ -116,7 +114,7 @@ class TestExhibitAPI(TestCase):
     def test_searching_exhibits_by_name(self):
         """Test that the exhibit can be searched using name"""
         exhibit = ExhibitFactory(owner=self.profile, name="test")
-        response = self.client.get(f"/api/v1/exhibits/?search=test")
+        response = self.client.get("/api/v1/exhibits/?search=test")
         self.assertEqual(response.status_code, 200)
         data = response.json()
         assert data["count"] == 1
@@ -130,7 +128,7 @@ class TestExhibitAPI(TestCase):
         exhibit = ExhibitFactory(owner=self.profile, name="test")
         ExhibitFactory(owner=self.profile, name="not similar 2")
         ExhibitFactory(owner=self.profile, name="not similar 3")
-        response = self.client.get(f"/api/v1/exhibits/?search=test")
+        response = self.client.get("/api/v1/exhibits/?search=test")
         self.assertEqual(response.status_code, 200)
         data = response.json()
         assert data["count"] == 1
@@ -145,7 +143,7 @@ class TestExhibitAPI(TestCase):
             owner=self.profile, name="test@#$%^&*() ação pátio câmara índio"
         )
 
-        response = self.client.get(f"/api/v1/exhibits/?search=test@")
+        response = self.client.get("/api/v1/exhibits/?search=test@")
         self.assertEqual(response.status_code, 200)
         data = response.json()
         assert data["count"] == 1
@@ -154,7 +152,7 @@ class TestExhibitAPI(TestCase):
         assert data["results"][0]["slug"] == exhibit.slug
         assert data["results"][0]["owner"] == self.profile.id
 
-        response = self.client.get(f"/api/v1/exhibits/?search=() a")
+        response = self.client.get("/api/v1/exhibits/?search=() a")
         self.assertEqual(response.status_code, 200)
         data = response.json()
         assert data["count"] == 1
@@ -163,7 +161,7 @@ class TestExhibitAPI(TestCase):
         assert data["results"][0]["slug"] == exhibit.slug
         assert data["results"][0]["owner"] == self.profile.id
 
-        response = self.client.get(f"/api/v1/exhibits/?search=ação pátio")
+        response = self.client.get("/api/v1/exhibits/?search=ação pátio")
         self.assertEqual(response.status_code, 200)
         data = response.json()
         assert data["count"] == 1
@@ -175,7 +173,7 @@ class TestExhibitAPI(TestCase):
     def test_searching_exhibits_by_invalid_name(self):
         """Test that the exhibit cannot be searched using invalid name"""
         _ = ExhibitFactory(owner=self.profile, name="test")
-        response = self.client.get(f"/api/v1/exhibits/?search=invalid")
+        response = self.client.get("/api/v1/exhibits/?search=invalid")
         self.assertEqual(response.status_code, 200)
         data = response.json()
         assert data["count"] == 0

--- a/src/core/urls.py
+++ b/src/core/urls.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 from django.urls import include, path, re_path
-from rest_framework_nested.routers import DefaultRouter
 
 from core.views.static_views import (
     community,

--- a/src/core/urls.py
+++ b/src/core/urls.py
@@ -21,22 +21,9 @@ from core.views.views import (
     see_all,
     service_worker,
 )
-from core.views.viewsets import (
-    ArtworkViewset,
-    ExhibitViewset,
-    MarkerViewset,
-    ObjectViewset,
-)
-
-api_router = DefaultRouter()
-api_router.register("markers", MarkerViewset, basename="marker")
-api_router.register("objects", ObjectViewset, basename="object")
-api_router.register("artworks", ArtworkViewset, basename="artwork")
-api_router.register("exhibits", ExhibitViewset, basename="exhibit")
 
 urlpatterns = [
     path("", home, name="home"),
-    path("api/v1/", include(api_router.urls)),
     path("documentation/", documentation, name="documentation"),
     path("community/", community, name="community"),
     path("collection/", collection, name="collection"),

--- a/src/users/admin.py
+++ b/src/users/admin.py
@@ -3,7 +3,7 @@ from typing import Any
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth.models import User
-from django.db.models import Count, Q
+from django.db.models import Q
 from django.db.models.query import QuerySet
 from django.http import HttpRequest
 from django.urls import reverse

--- a/src/users/models.py
+++ b/src/users/models.py
@@ -7,13 +7,15 @@ from .choices import COUNTRY_CHOICES
 
 
 class Profile(models.Model):
-    user = models.OneToOneField(User, on_delete=models.DO_NOTHING)
+    user = models.OneToOneField(
+        User, on_delete=models.DO_NOTHING, related_name="profile"
+    )
     bio = models.TextField(max_length=500, blank=True)
     country = models.CharField(max_length=2, choices=COUNTRY_CHOICES, blank=True)
     personal_site = models.URLField()
 
     def __str__(self):
-        return self.user.username
+        return str(self.id)
 
     class Meta:
         permissions = [

--- a/src/users/serializers.py
+++ b/src/users/serializers.py
@@ -1,4 +1,5 @@
 from rest_framework.serializers import ModelSerializer, SerializerMethodField
+from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 
 from users.models import Profile
 
@@ -19,3 +20,14 @@ class ProfileSerializer(ModelSerializer):
 
     def get_user_id(self, obj):
         return obj.user.id
+
+
+class JandigJWTSerializer(TokenObtainPairSerializer):
+    @classmethod
+    def get_token(cls, user):
+        token = super().get_token(user)
+        # Add custom claims
+        token["user_profile_id"] = user.profile.id
+        token["user_id"] = user.id
+        token["username"] = user.username
+        return token

--- a/src/users/serializers.py
+++ b/src/users/serializers.py
@@ -8,10 +8,7 @@ class ProfileSerializer(ModelSerializer):
 
     class Meta:
         model = Profile
-        fields = (
-            "id",
-            "username",
-        )
+        fields = ("id", "username", "user_id")
         read_only_fields = (
             "id",
             "uploaded_at",
@@ -19,3 +16,6 @@ class ProfileSerializer(ModelSerializer):
 
     def get_username(self, obj):
         return obj.user.username
+
+    def get_user_id(self, obj):
+        return obj.user.id

--- a/src/users/tests/test_auth_api.py
+++ b/src/users/tests/test_auth_api.py
@@ -1,0 +1,45 @@
+from django.conf import settings
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+
+from users.serializers import ProfileSerializer
+from users.tests.factory import ProfileFactory, UserFactory
+
+
+class TestAuthAPI(TestCase):
+    def setUp(self):
+        self.user = UserFactory(username="user")
+        self.profile = ProfileFactory(user=self.user)
+        self.user.set_password("password")
+        self.user.save()
+
+    def test_login_success(self):
+        """Test that the login endpoint works"""
+        response = self.client.post(
+            "/api/v1/auth/login/",
+            {"username": self.user.username, "password": "password"},
+        )
+        data = response.json()
+        print(data)
+        assert response.status_code == 200
+        assert data["access"] is not None
+        assert data["user"]["pk"] == self.user.id
+        assert data["user"]["username"] == self.user.username
+
+    def test_verify_token_success(self):
+        """Test that the verify token endpoint works"""
+        response = self.client.post(
+            "/api/v1/auth/login/", {"username": "user", "password": "password"}
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        token = data["access"]
+
+        response = self.client.post("/api/v1/auth/verify/", {"token": token})
+        self.assertEqual(response.status_code, 200)
+
+    def test_verify_token_fail(self):
+        """Test that verifying invalid tokens wont return 200"""
+
+        response = self.client.post("/api/v1/auth/verify/", {"token": "invalid-token"})
+        self.assertEqual(response.status_code, 401)

--- a/src/users/tests/test_auth_api.py
+++ b/src/users/tests/test_auth_api.py
@@ -1,8 +1,8 @@
-from django.conf import settings
-from django.core.files.uploadedfile import SimpleUploadedFile
+import base64
+import json
+
 from django.test import TestCase
 
-from users.serializers import ProfileSerializer
 from users.tests.factory import ProfileFactory, UserFactory
 
 
@@ -20,11 +20,20 @@ class TestAuthAPI(TestCase):
             {"username": self.user.username, "password": "password"},
         )
         data = response.json()
-        print(data)
         assert response.status_code == 200
         assert data["access"] is not None
-        assert data["user"]["pk"] == self.user.id
-        assert data["user"]["username"] == self.user.username
+        assert data["refresh"] is not None
+        print(data)
+        # Access JWT token payload
+        payload = data["access"].split(".")[1]
+        # Decode the base 64 payload
+        decoded_payload = base64.b64decode(payload + "==").decode("utf-8")
+        json_payload = json.loads(decoded_payload)
+
+        # Check the payload contains the user id
+        assert int(json_payload["user_profile_id"]) == self.user.profile.id
+        assert int(json_payload["user_id"]) == self.user.id
+        assert json_payload["username"] == self.user.username
 
     def test_verify_token_success(self):
         """Test that the verify token endpoint works"""
@@ -43,3 +52,28 @@ class TestAuthAPI(TestCase):
 
         response = self.client.post("/api/v1/auth/verify/", {"token": "invalid-token"})
         self.assertEqual(response.status_code, 401)
+
+    def test_refresh_token_success(self):
+        """Test that the refresh token endpoint works"""
+        response = self.client.post(
+            "/api/v1/auth/login/", {"username": "user", "password": "password"}
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        assert data["refresh"] is not None
+        assert data["access"] is not None
+        old_access_token = data["access"]
+        refresh_token = data["refresh"]
+
+        response = self.client.post("/api/v1/auth/verify/", {"token": old_access_token})
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.post("/api/v1/auth/refresh/", {"refresh": refresh_token})
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        assert data["access"] is not None
+        access_token = data["access"]
+        assert access_token != old_access_token
+
+        response = self.client.post("/api/v1/auth/verify/", {"token": access_token})
+        self.assertEqual(response.status_code, 200)

--- a/src/users/tests/test_profile_api.py
+++ b/src/users/tests/test_profile_api.py
@@ -1,0 +1,90 @@
+"""Tests for the Jandig Profiles API"""
+
+from django.conf import settings
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+
+from users.serializers import ProfileSerializer
+from users.tests.factory import ProfileFactory, UserFactory
+
+
+class TestProfileAPI(TestCase):
+    def test_url(self):
+        """Test that the root page of the api exists"""
+        response = self.client.get("/api/v1/profiles/")
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["count"], 0)
+        self.assertEqual(data["next"], None)
+        self.assertEqual(data["previous"], None)
+        self.assertEqual(data["results"], [])
+
+    def test_api_profiles_lists_one_profile(self):
+        """API returns one profile if there is one profile"""
+        user = UserFactory(username="testuserprofile")
+        profile = ProfileFactory(user=user)
+        response = self.client.get("/api/v1/profiles/")
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        assert data["count"] == 1
+        assert data["results"][0]["id"] == profile.id
+        assert data["results"][0]["user_id"] == profile.user.id
+        assert data["results"][0]["username"] == profile.user.username
+        assert data["results"] == ProfileSerializer([profile], many=True).data
+
+    def test_api_profiles_lists_multiple_profiles(self):
+        """API returns multiple profiles if there are multiple profiles"""
+        for i in range(0, settings.PAGE_SIZE + 1):
+            ProfileFactory(user=UserFactory(username=f"user_{i}"))
+        response = self.client.get("/api/v1/profiles/")
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["count"], settings.PAGE_SIZE + 1)
+        self.assertEqual(
+            data["next"],
+            f"http://testserver/api/v1/profiles/?limit={settings.PAGE_SIZE}&offset={settings.PAGE_SIZE}",
+        )
+
+    def test_retrieve_profile_by_id(self):
+        """API returns one profile if there is one profile"""
+        user = UserFactory(username="testuserprofile")
+        profile = ProfileFactory(user=user)
+        response = self.client.get(f"/api/v1/profiles/{profile.id}/")
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        assert data["id"] == profile.id
+        assert data["user_id"] == profile.user.id
+        assert data["username"] == profile.user.username
+        assert data == ProfileSerializer(profile).data
+
+    def test_search_by_user_id(self):
+        """API returns one profile if there is one profile"""
+        user = UserFactory(username="testuserprofile")
+        profile = ProfileFactory(user=user)
+        response = self.client.get(f"/api/v1/profiles/?user={profile.user.id}")
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        assert data["count"] == 1
+        assert data["results"][0]["id"] == profile.id
+        assert data["results"][0]["user_id"] == profile.user.id
+        assert data["results"][0]["username"] == profile.user.username
+
+    def test_search_by_invalid_ids(self):
+        """API doens't fail with invalid user ids"""
+        response = self.client.get(f"/api/v1/profiles/?user=99999")
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        assert data["count"] == 0
+        assert data["results"] == []
+
+        response = self.client.get(f"/api/v1/profiles/?user=invalid")
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        assert data["count"] == 0
+        assert data["results"] == []
+
+        response = self.client.get(f"/api/v1/profiles/?user=")
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        assert data["count"] == 0
+        assert data["results"] == []

--- a/src/users/tests/test_profile_api.py
+++ b/src/users/tests/test_profile_api.py
@@ -1,7 +1,6 @@
 """Tests for the Jandig Profiles API"""
 
 from django.conf import settings
-from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 
 from users.serializers import ProfileSerializer
@@ -71,19 +70,19 @@ class TestProfileAPI(TestCase):
 
     def test_search_by_invalid_ids(self):
         """API doens't fail with invalid user ids"""
-        response = self.client.get(f"/api/v1/profiles/?user=99999")
+        response = self.client.get("/api/v1/profiles/?user=99999")
         self.assertEqual(response.status_code, 200)
         data = response.json()
         assert data["count"] == 0
         assert data["results"] == []
 
-        response = self.client.get(f"/api/v1/profiles/?user=invalid")
+        response = self.client.get("/api/v1/profiles/?user=invalid")
         self.assertEqual(response.status_code, 200)
         data = response.json()
         assert data["count"] == 0
         assert data["results"] == []
 
-        response = self.client.get(f"/api/v1/profiles/?user=")
+        response = self.client.get("/api/v1/profiles/?user=")
         self.assertEqual(response.status_code, 200)
         data = response.json()
         assert data["count"] == 0

--- a/src/users/viewsets.py
+++ b/src/users/viewsets.py
@@ -1,0 +1,10 @@
+from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
+from rest_framework.viewsets import GenericViewSet
+
+from users.models import Profile
+from users.serializers import ProfileSerializer
+
+
+class ProfileViewset(ListModelMixin, RetrieveModelMixin, GenericViewSet):
+    serializer_class = ProfileSerializer
+    queryset = Profile.objects.select_related("user").all().order_by("id")

--- a/src/users/viewsets.py
+++ b/src/users/viewsets.py
@@ -7,4 +7,15 @@ from users.serializers import ProfileSerializer
 
 class ProfileViewset(ListModelMixin, RetrieveModelMixin, GenericViewSet):
     serializer_class = ProfileSerializer
-    queryset = Profile.objects.select_related("user").all().order_by("id")
+
+    def get_queryset(self):
+        """Optionally finds profile based on user id"""
+        queryset = Profile.objects.select_related("user").all()
+        user_id = self.request.query_params.get("user", None)
+        if user_id:
+            try:
+                user_id = int(user_id)
+            except ValueError:
+                return queryset.none()
+            return queryset.filter(user__id=user_id)
+        return queryset

--- a/uv.lock
+++ b/uv.lock
@@ -263,6 +263,20 @@ wheels = [
 ]
 
 [[package]]
+name = "djangorestframework-simplejwt"
+version = "5.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "djangorestframework" },
+    { name = "pyjwt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/1e/0d4439d0fa1d93599fbcfc56efdc02cbf012e3a4b4ef90c835e0a51017d4/djangorestframework_simplejwt-5.5.0.tar.gz", hash = "sha256:474a1b737067e6462b3609627a392d13a4da8a08b1f0574104ac6d7b1406f90e", size = 97946 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/b4/d1c1750aa7c8cc07e4974275f96b9b9b3a38e95ff734e14b4e97790c8974/djangorestframework_simplejwt-5.5.0-py3-none-any.whl", hash = "sha256:4ef6b38af20cdde4a4a51d1fd8e063cbbabb7b45f149cc885d38d905c5a62edb", size = 103480 },
+]
+
+[[package]]
 name = "docutils"
 version = "0.21.2"
 source = { registry = "https://pypi.org/simple" }
@@ -413,7 +427,7 @@ wheels = [
 
 [[package]]
 name = "jandig"
-version = "1.4.3"
+version = "1.5.0"
 source = { virtual = "." }
 dependencies = [
     { name = "babel" },
@@ -425,6 +439,7 @@ dependencies = [
     { name = "django-htmx" },
     { name = "django-storages" },
     { name = "djangorestframework" },
+    { name = "djangorestframework-simplejwt" },
     { name = "drf-nested-routers" },
     { name = "gevent" },
     { name = "gunicorn" },
@@ -463,6 +478,7 @@ requires-dist = [
     { name = "django-htmx", specifier = "~=1.21" },
     { name = "django-storages", specifier = "~=1.14" },
     { name = "djangorestframework", specifier = "~=3.15" },
+    { name = "djangorestframework-simplejwt", specifier = ">=5.5.0" },
     { name = "drf-nested-routers", specifier = "~=0.94" },
     { name = "gevent", specifier = "~=24.11" },
     { name = "gunicorn", specifier = "~=23.0" },
@@ -649,6 +665,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293 },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/68/ce067f09fca4abeca8771fe667d89cc347d1e99da3e093112ac329c6020e/pyjwt-2.9.0.tar.gz", hash = "sha256:7e1e5b56cc735432a7369cbfa0efe50fa113ebecdc04ae6922deba8b84582d0c", size = 78825 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/84/0fdf9b18ba31d69877bd39c9cd6052b47f3761e9910c15de788e519f079f/PyJWT-2.9.0-py3-none-any.whl", hash = "sha256:3b02fb0f44517787776cf48f2ae25d8e14f300e6d7545a4315cee571a415e850", size = 22344 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Created API for Profiles and Authentication endpoints.

`/api/v1/profiles/`
`/api/v1/profiles/?user=<id>`
`/api/v1/auth/login`
`/api/v1/auth/verify`
`/api/v1/auth/refresh`

### Have you confirmed the application builds locally without error? See [here](https://github.com/memeLab/Jandig#running).
- [x] Yes