### PR TITLE
Fix related content page

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Jandig"
-version = "1.5.0"
+version = "1.5.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -47,7 +47,7 @@ HEALTH_CHECK_URL = env("HEALTH_CHECK_URL", default="api/v1/status/")
 SENTRY_TRACES_SAMPLE_RATE = env("SENTRY_TRACES_SAMPLE_RATE", default=0.1)
 SENTRY_PROFILES_SAMPLE_RATE = env("SENTRY_PROFILES_SAMPLE_RATE", default=0.1)
 SENTRY_ENVIRONMENT = env("SENTRY_ENVIRONMENT", default="")
-SENTRY_RELEASE = env("SENTRY_RELEASE", default="1.5.0")
+SENTRY_RELEASE = env("SENTRY_RELEASE", default="1.5.1")
 
 
 def traces_sampler(sampling_context):

--- a/src/core/tests/test_artworks_api.py
+++ b/src/core/tests/test_artworks_api.py
@@ -53,3 +53,10 @@ class TestArtworkAPI(TestCase):
 
         response = self.client.get(f"/api/v1/artworks/{str(artwork.id)}/")
         self.assertEqual(response.status_code, 200)
+        data = response.json()
+        assert data["id"] == artwork.id
+        assert data["title"] == artwork.title
+        assert data["description"] == artwork.description
+        assert data["author"]["id"] == self.profile.id
+        assert data["marker"]["id"] == marker.id
+        assert data["augmented"]["id"] == obj.id

--- a/src/core/tests/test_related_content_view.py
+++ b/src/core/tests/test_related_content_view.py
@@ -14,8 +14,25 @@ class TestRelatedContentView(TestCase):
         response = self.client.get(
             reverse("related-content"), {"id": 1, "type": "invalid"}
         )
-        assert "artworks" not in response.context
-        assert "exhibits" not in response.context
+        assert response.status_code == 404
+        response = self.client.get(
+            reverse("related-content"), {"id": "aaaa", "type": "object"}
+        )
+        assert response.status_code == 404
+        response = self.client.get(reverse("related-content"), {"id": 1, "type": ""})
+        assert response.status_code == 404
+        response = self.client.get(reverse("related-content"), {"id": 1})
+        assert response.status_code == 404
+        response = self.client.get(reverse("related-content"), {"type": "object"})
+        assert response.status_code == 404
+        response = self.client.get(reverse("related-content"), {})
+        assert response.status_code == 404
+        response = self.client.get(
+            reverse("related-content"), {"id": "", "type": "object"}
+        )
+        assert response.status_code == 404
+        response = self.client.get(reverse("related-content"), {"id": 1, "type": 1})
+        assert response.status_code == 404
 
     def test_object_related_content(self):
         # Create object first

--- a/src/core/tests/test_related_content_view.py
+++ b/src/core/tests/test_related_content_view.py
@@ -1,0 +1,81 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from core.tests.factory import (
+    ArtworkFactory,
+    ExhibitFactory,
+    MarkerFactory,
+    ObjectFactory,
+)
+
+
+class TestRelatedContentView(TestCase):
+    def test_invalid_type(self):
+        response = self.client.get(
+            reverse("related-content"), {"id": 1, "type": "invalid"}
+        )
+        assert "artworks" not in response.context
+        assert "exhibits" not in response.context
+
+    def test_object_related_content(self):
+        # Create object first
+        obj = ObjectFactory()
+        # Create artworks that references the object
+        artwork1 = ArtworkFactory(augmented=obj)
+        artwork2 = ArtworkFactory(augmented=obj)
+        artwork3 = ArtworkFactory(augmented=obj)
+
+        # Create exhibits and add artworks to it
+        exhibit1 = ExhibitFactory(artworks=[artwork1, artwork2])
+        exhibit2 = ExhibitFactory(artworks=[artwork3])
+        exhibit3 = ExhibitFactory(artworks=[artwork1, artwork3])
+
+        response = self.client.get(
+            reverse("related-content"), {"id": obj.id, "type": "object"}
+        )
+        assert artwork1 in list(response.context["artworks"])
+        assert artwork2 in list(response.context["artworks"])
+        assert artwork3 in list(response.context["artworks"])
+        assert exhibit1 in list(response.context["exhibits"])
+        assert exhibit2 in list(response.context["exhibits"])
+        assert exhibit3 in list(response.context["exhibits"])
+        assert len(response.context["artworks"]) == 3
+        assert len(response.context["exhibits"]) == 3
+
+    def test_marker_related_content(self):
+        # Create marker first
+        marker = MarkerFactory()
+
+        # Create artworks that references the marker
+        artwork1 = ArtworkFactory(marker=marker)
+        artwork2 = ArtworkFactory(marker=marker)
+        artwork3 = ArtworkFactory(marker=marker)
+
+        # Create exhibits and add artworks to it
+        exhibit1 = ExhibitFactory(artworks=[artwork1, artwork2])
+        exhibit2 = ExhibitFactory(artworks=[artwork3])
+        exhibit3 = ExhibitFactory(artworks=[artwork1, artwork3])
+
+        response = self.client.get(
+            reverse("related-content"), {"id": marker.id, "type": "marker"}
+        )
+        assert artwork1 in list(response.context["artworks"])
+        assert artwork2 in list(response.context["artworks"])
+        assert artwork3 in list(response.context["artworks"])
+        assert exhibit1 in list(response.context["exhibits"])
+        assert exhibit2 in list(response.context["exhibits"])
+        assert exhibit3 in list(response.context["exhibits"])
+        assert len(response.context["artworks"]) == 3
+        assert len(response.context["exhibits"]) == 3
+
+    def test_artwork_related_content(self):
+        artwork = ArtworkFactory()
+        # Create exhibits that references the artwork
+        exhibit1 = ExhibitFactory(artworks=[artwork])
+        exhibit2 = ExhibitFactory(artworks=[artwork])
+        exhibit3 = ExhibitFactory(artworks=[artwork])
+
+        response = self.client.get(
+            reverse("related-content"), {"id": artwork.id, "type": "artwork"}
+        )
+        assert list(response.context["exhibits"]) == [exhibit1, exhibit2, exhibit3]

--- a/src/core/urls.py
+++ b/src/core/urls.py
@@ -17,6 +17,7 @@ from core.views.views import (
     exhibit_detail,
     exhibit_select,
     manifest,
+    related_content,
     see_all,
     service_worker,
 )
@@ -30,6 +31,7 @@ urlpatterns = [
     path("exhibit/", exhibit_detail, name="exhibit-detail"),
     path("artwork/", artwork_preview, name="artwork-preview"),
     path("generator/", marker_generator, name="marker-generator"),
+    path("related-content", related_content, name="related-content"),
     path("sw.js", service_worker, name="sw"),
     path("manifest.json", manifest, name="manifest"),
     path("i18n/", include("django.conf.urls.i18n")),

--- a/src/core/views/views.py
+++ b/src/core/views/views.py
@@ -68,22 +68,27 @@ def related_content(request):
         element = Object.objects.get(id=element_id)
 
         artworks = element.artworks_list
-        exhibits = element.exhibits_list
+        exhibits = Exhibit.objects.filter(
+            artworks__id__in=element.artworks.values_list("id")
+        ).distinct()
 
         ctx = {"artworks": artworks, "exhibits": exhibits, "seeall:": False}
     elif element_type == "marker":
         element = Marker.objects.get(id=element_id)
 
         artworks = element.artworks_list
-        exhibits = element.exhibits_list
+        exhibits = Exhibit.objects.filter(
+            artworks__id__in=element.artworks.values_list("id")
+        ).distinct()
 
         ctx = {"artworks": artworks, "exhibits": exhibits, "seeall:": False}
     elif element_type == "artwork":
         element = Artwork.objects.get(id=element_id)
 
-        exhibits = element.exhibits_list
+        exhibits = element.exhibits.all()
 
         ctx = {"exhibits": exhibits, "seeall:": False}
+
     return render(request, "core/collection.jinja2", ctx)
 
 

--- a/src/core/views/views.py
+++ b/src/core/views/views.py
@@ -61,9 +61,18 @@ def collection(request):
 def related_content(request):
     element_id = request.GET.get("id")
     element_type = request.GET.get("type")
+    if element_id is None or element_type is None:
+        raise Http404
+    if element_type not in ["object", "marker", "artwork"]:
+        raise Http404
+    # Bots insert random strings in the id parameter, element_id should be an integer
+    try:
+        element_id = int(element_id)
+    except ValueError:
+        raise Http404
+
     element = None
     ctx = {}
-
     if element_type in ["object", "marker"]:
         if element_type == "object":
             element = (

--- a/src/core/views/views.py
+++ b/src/core/views/views.py
@@ -57,6 +57,36 @@ def collection(request):
     return render(request, "core/collection.jinja2", ctx)
 
 
+@require_http_methods(["GET"])
+def related_content(request):
+    element_id = request.GET.get("id")
+    element_type = request.GET.get("type")
+    element = None
+    ctx = {}
+
+    if element_type == "object":
+        element = Object.objects.get(id=element_id)
+
+        artworks = element.artworks_list
+        exhibits = element.exhibits_list
+
+        ctx = {"artworks": artworks, "exhibits": exhibits, "seeall:": False}
+    elif element_type == "marker":
+        element = Marker.objects.get(id=element_id)
+
+        artworks = element.artworks_list
+        exhibits = element.exhibits_list
+
+        ctx = {"artworks": artworks, "exhibits": exhibits, "seeall:": False}
+    elif element_type == "artwork":
+        element = Artwork.objects.get(id=element_id)
+
+        exhibits = element.exhibits_list
+
+        ctx = {"exhibits": exhibits, "seeall:": False}
+    return render(request, "core/collection.jinja2", ctx)
+
+
 @cache_page(60 * 2)
 @require_http_methods(["GET"])
 def see_all(request, which="", page=1):

--- a/src/users/jinja2/users/components/elements-modal.jinja2
+++ b/src/users/jinja2/users/components/elements-modal.jinja2
@@ -131,7 +131,7 @@
                     url: elemUrl,
                     success: function(data){
                         elementAuthor(data['author'].username);
-                        usedInExhibit(data['id_marker'], data['id_object'], data['exhibits_count'], data['marker'], data['augmented'], element_id);
+                        usedInExhibit(data['marker']['id'], data['augmented']['id'], data['exhibits_count'], data['marker'], data['augmented'], element_id);
                         replaceButtons(data['title'], data['description']);
                         downloadElement(data['type'], data['augmented'].file_size/1000, data['augmented'].source);
                     }

--- a/src/users/urls.py
+++ b/src/users/urls.py
@@ -19,7 +19,6 @@ from .views import (
     object_upload,
     permission_denied,
     profile,
-    related_content,
     signup,
 )
 
@@ -64,5 +63,4 @@ urlpatterns = [
     path("moderator-page/", mod, name="moderator-page"),
     path("permission-denied/", permission_denied, name="permission-denied"),
     path("content/mod-delete/", mod_delete, name="mod-delete-content"),
-    path("related-content", related_content, name="related-content"),
 ]

--- a/src/users/views.py
+++ b/src/users/views.py
@@ -539,36 +539,6 @@ def delete_content_Moderator(instance, user, model):
             instance.delete()
 
 
-@require_http_methods(["GET"])
-def related_content(request):
-    element_id = request.GET.get("id")
-    element_type = request.GET.get("type")
-    element = None
-    ctx = {}
-
-    if element_type == "object":
-        element = Object.objects.get(id=element_id)
-
-        artworks = element.artworks_list
-        exhibits = element.exhibits_list
-
-        ctx = {"artworks": artworks, "exhibits": exhibits, "seeall:": False}
-    elif element_type == "marker":
-        element = Marker.objects.get(id=element_id)
-
-        artworks = element.artworks_list
-        exhibits = element.exhibits_list
-
-        ctx = {"artworks": artworks, "exhibits": exhibits, "seeall:": False}
-    elif element_type == "artwork":
-        element = Artwork.objects.get(id=element_id)
-
-        exhibits = element.exhibits_list
-
-        ctx = {"exhibits": exhibits, "seeall:": False}
-    return render(request, "core/collection.jinja2", ctx)
-
-
 @login_required
 @require_http_methods(["GET"])
 def mod_delete(request):


### PR DESCRIPTION
## Description

Related content page was raising exceptions after the last performance refactors. This PR fixes the errors and creates unit tests to ensure this feature works.

## General tasks performed
* Fixed IDs on modal pages
* Fixed related content pages
* Improved performance of queries on related content pages
* Created tests for the related_content view
* Moved related_content view from app users to core

### Have you confirmed the application builds locally without error? See [here](https://github.com/memeLab/Jandig#running).
- [x] Yes