### PR TITLE
Generate html with Python

### DIFF
--- a/.github/workflows/PipelineRC.yml
+++ b/.github/workflows/PipelineRC.yml
@@ -106,7 +106,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: jandigarte/django:${GITHUB_REF#refs/tags/}
+          tags: jandigarte/django:${{ github.ref_name }}
           target: base
       
       - name: Configure AWS credentials

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
   "sentry-sdk[django]~=2.20",
   "Sphinx~=8.1",
   "djangorestframework-simplejwt>=5.5.0",
+  "fast-html>=1.0.11",
 ]
 
 [dependency-groups]

--- a/src/core/jinja2/core/collection.jinja2
+++ b/src/core/jinja2/core/collection.jinja2
@@ -20,7 +20,7 @@
                         {% include "users/components/item-list.jinja2" %}
                     {% endwith %}
                     {% if seeall == False %}
-                    <a href = "/see_all?which={{element_type}}s" class="seeall">{{_("All " + element_type.capitalize() + "s")}}</a>
+                    <a href = "/see_all/?which={{element_type}}s" class="seeall">{{_("All " + element_type.capitalize() + "s")}}</a>
                     {% endif %}
                     {% if seeall == True %}
                         <nav> 

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -5,7 +5,7 @@ from django.core.files.base import ContentFile
 from django.db import models
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
-from fast_html import img, render, video
+from fast_html import div, img, render, video
 from PIL import Image
 from pymarker.core import generate_marker_from_image, generate_patt_from_image
 
@@ -278,6 +278,15 @@ class Artwork(models.Model):
 
     def __str__(self):
         return self.title
+
+    def as_html_thumbnail(self):
+        return render(
+            [
+                self.marker.as_html_thumbnail(),
+                div(class_="separator"),
+                self.augmented.as_html_thumbnail(),
+            ]
+        )
 
 
 @receiver(post_delete, sender=Object)

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -5,6 +5,7 @@ from django.core.files.base import ContentFile
 from django.db import models
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
+from fast_html import img, render, video
 from PIL import Image
 from pymarker.core import generate_marker_from_image, generate_patt_from_image
 
@@ -66,6 +67,29 @@ class Marker(models.Model):
         if self.artworks_count > 0:
             return True
         return False
+
+    def as_html(self, height: int = None, width: int = None):
+        if not height:
+            height = self.height
+        if not width:
+            width = self.width
+        attributes = {
+            "id": self.id,
+            "title": self.title,
+            "class_": "trigger-modal",
+            "data_elem_type": "marker",
+            "src": self.source.url,
+        }
+        return render(
+            img(
+                **attributes,
+                height=height,
+                width=width,
+            )
+        )
+
+    def as_html_thumbnail(self):
+        return self.as_html(height=50, width=50)
 
 
 class Object(models.Model):
@@ -188,6 +212,39 @@ class Object(models.Model):
         if self.source.name.endswith(".mp4") or self.source.name.endswith(".webm"):
             return True
         return False
+
+    def as_html(self, height: int = None, width: int = None):
+        if not height:
+            height = self.height
+        if not width:
+            width = self.width
+        attributes = {
+            "id": self.id,
+            "title": self.title,
+            "class_": "trigger-modal",
+            "data_elem_type": "object",
+            "src": self.source.url,
+            "height": height,
+            "width": width,
+        }
+        if self.is_video:
+            return render(
+                video(
+                    autoplay=True,
+                    loop=True,
+                    muted=True,
+                    **attributes,
+                )
+            )
+        else:
+            return render(img(**attributes))
+
+    def as_html_thumbnail(self):
+        default_thumbnail_height = 50
+        default_thumbnail_width = 50
+        height = default_thumbnail_height * self.yproportion
+        width = default_thumbnail_width * self.xproportion
+        return self.as_html(height=height, width=width)
 
 
 class Artwork(models.Model):

--- a/src/core/tests/factory.py
+++ b/src/core/tests/factory.py
@@ -129,7 +129,7 @@ class ExhibitFactory(DjangoModelFactory):
     owner = SubFactory(ProfileFactory)  # Use ProfileFactory for the owner
     name = Faker("sentence", nb_words=3)  # Generate a random unique name
     slug = LazyAttribute(
-        lambda obj: obj.name.lower().replace(" ", "-")
+        lambda obj: obj.name.lower().replace(" ", "-").replace(".", "")
     )  # Generate a slug based on the name
 
     @classmethod

--- a/src/core/tests/test_html_thumbnail_generators.py
+++ b/src/core/tests/test_html_thumbnail_generators.py
@@ -1,0 +1,87 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from core.tests.factory import MarkerFactory, ObjectFactory, ArtworkFactory, ExhibitFactory
+from core.models import DEFAULT_OBJECT_THUMBNAIL_HEIGHT, DEFAULT_OBJECT_THUMBNAIL_WIDTH
+
+class TestMarkerThumbnailGenerators(TestCase):
+    def test_thumbnail_generator(self):
+        # This is a placeholder for the actual test
+        self.assertTrue(True)
+
+class TestObjectThumbnailGenerators(TestCase):
+    def setUp(self):
+        self.image_object = ObjectFactory(
+            title="Test Image",
+            source="objects/test.gif",
+            scale="2 1",
+            position="0 1 0"
+        )
+        self.video_object = ObjectFactory(
+            title="Test Video",
+            source="objects/test.mp4",
+            scale="1 1",
+            position="1 0 0"
+        )
+
+    def test_gif_object_as_html_is_image(self):
+        html = self.image_object.as_html(height=100, width=200)
+        assert f'height="100"' in html
+        assert f'width="200"' in html
+        assert f'id="{self.image_object.id}"' in html
+        assert f'title="{self.image_object.title}"' in html
+        assert 'class="trigger-modal"' in html
+        assert 'data-elem-type="object"' in html
+        assert self.image_object.source.url in html
+        assert '<img' in html
+
+    def test_video_object_as_html_is_video(self):
+        html = self.video_object.as_html(height=100, width=200)
+        assert f'height="100"' in html
+        assert f'width="200"' in html
+        assert f'id="{self.video_object.id}"' in html
+        assert 'autoplay' in html
+        assert 'loop' in html
+        assert 'data-elem-type="object"' in html
+        assert 'class="trigger-modal"' in html
+        assert 'muted' in html
+        assert '<video' in html
+
+    def test_object_thumbnail_follows_proportion(self):
+        html = self.image_object.as_html_thumbnail(editable=False)
+        expected_height = DEFAULT_OBJECT_THUMBNAIL_HEIGHT * self.image_object.yproportion
+        expected_width = DEFAULT_OBJECT_THUMBNAIL_WIDTH * self.image_object.xproportion
+        
+        assert f'height="{expected_height}"' in html
+        assert f'width="{expected_width}"' in html
+        assert 'href="/edit-object' not in html
+        assert 'href="/delete-content' not in html
+
+    def test_object_thumbnail_can_be_edited(self):
+        html = self.image_object.as_html_thumbnail(editable=True)
+        
+        edit_url = reverse('edit-object', query={'id': self.image_object.id})
+        delete_url = reverse('delete-content', 
+                           query={'content_type': 'object', 
+                                 'id': self.image_object.id})
+        
+        assert f'href="{edit_url}"' in html
+        assert f'href="{delete_url}"' in html
+
+    def test_object_in_use_cant_be_edited(self):
+        # Create an artwork using this object to mark it as "in use"
+        ArtworkFactory(augmented=self.image_object)
+        
+        html = self.image_object.as_html_thumbnail(editable=True)
+        assert reverse('edit-object') not in html
+        assert reverse('delete-content') not in html
+
+class TestArtworkThumbnailGenerators(TestCase):
+    def test_thumbnail_generator(self):
+        # This is a placeholder for the actual test
+        self.assertTrue(True)
+
+class TestExhibitThumbnailGenerators(TestCase):
+    def test_thumbnail_generator(self):
+        # This is a placeholder for the actual test
+        self.assertTrue(True)

--- a/src/core/tests/test_html_thumbnail_generators.py
+++ b/src/core/tests/test_html_thumbnail_generators.py
@@ -1,87 +1,228 @@
 from django.test import TestCase
 from django.urls import reverse
 
-from core.tests.factory import MarkerFactory, ObjectFactory, ArtworkFactory, ExhibitFactory
-from core.models import DEFAULT_OBJECT_THUMBNAIL_HEIGHT, DEFAULT_OBJECT_THUMBNAIL_WIDTH
+from core.models import (
+    DEFAULT_MARKER_THUMBNAIL_HEIGHT,
+    DEFAULT_MARKER_THUMBNAIL_WIDTH,
+    DEFAULT_OBJECT_THUMBNAIL_HEIGHT,
+    DEFAULT_OBJECT_THUMBNAIL_WIDTH,
+)
+from core.tests.factory import (
+    ArtworkFactory,
+    ExhibitFactory,
+    MarkerFactory,
+    ObjectFactory,
+)
+
 
 class TestMarkerThumbnailGenerators(TestCase):
-    def test_thumbnail_generator(self):
-        # This is a placeholder for the actual test
-        self.assertTrue(True)
+    def setUp(self):
+        self.marker = MarkerFactory(
+            title="Test Marker", source="markers/test.png", author="Test Author"
+        )
+
+    def test_marker_as_html(self):
+        html = self.marker.as_html(height=100, width=200)
+        assert 'height="100"' in html
+        assert 'width="200"' in html
+        assert f'id="{self.marker.id}"' in html
+        assert f'title="{self.marker.title}"' in html
+        assert 'class="trigger-modal"' in html
+        assert 'data-elem-type="marker"' in html
+        assert self.marker.source.url in html
+        assert "<img" in html
+
+    def test_marker_thumbnail_not_editable(self):
+        html = self.marker.as_html_thumbnail(editable=False)
+        assert f'height="{DEFAULT_MARKER_THUMBNAIL_HEIGHT}"' in html
+        assert f'width="{DEFAULT_MARKER_THUMBNAIL_WIDTH}"' in html
+        assert reverse("edit-marker") not in html
+        assert reverse("delete-content") not in html
+
+    def test_marker_thumbnail_editable(self):
+        html = self.marker.as_html_thumbnail(editable=True)
+
+        edit_url = reverse("edit-marker", query={"id": self.marker.id})
+        delete_url = reverse(
+            "delete-content", query={"content_type": "marker", "id": self.marker.id}
+        )
+
+        assert f'href="{edit_url}"' in html
+        assert f'href="{delete_url}"' in html
+
+    def test_marker_in_use_cant_be_edited(self):
+        # Create an artwork using this marker to mark it as "in use"
+        ArtworkFactory(marker=self.marker)
+
+        html = self.marker.as_html_thumbnail(editable=True)
+        assert reverse("edit-marker") not in html
+        assert reverse("delete-content") not in html
+
 
 class TestObjectThumbnailGenerators(TestCase):
     def setUp(self):
         self.image_object = ObjectFactory(
-            title="Test Image",
-            source="objects/test.gif",
-            scale="2 1",
-            position="0 1 0"
+            title="Test Image", source="objects/test.gif", scale="2 1", position="0 1 0"
         )
         self.video_object = ObjectFactory(
-            title="Test Video",
-            source="objects/test.mp4",
-            scale="1 1",
-            position="1 0 0"
+            title="Test Video", source="objects/test.mp4", scale="1 1", position="1 0 0"
         )
 
     def test_gif_object_as_html_is_image(self):
         html = self.image_object.as_html(height=100, width=200)
-        assert f'height="100"' in html
-        assert f'width="200"' in html
+        assert 'height="100"' in html
+        assert 'width="200"' in html
         assert f'id="{self.image_object.id}"' in html
         assert f'title="{self.image_object.title}"' in html
         assert 'class="trigger-modal"' in html
         assert 'data-elem-type="object"' in html
         assert self.image_object.source.url in html
-        assert '<img' in html
+        assert "<img" in html
 
     def test_video_object_as_html_is_video(self):
         html = self.video_object.as_html(height=100, width=200)
-        assert f'height="100"' in html
-        assert f'width="200"' in html
+        assert 'height="100"' in html
+        assert 'width="200"' in html
         assert f'id="{self.video_object.id}"' in html
-        assert 'autoplay' in html
-        assert 'loop' in html
+        assert "autoplay" in html
+        assert "loop" in html
         assert 'data-elem-type="object"' in html
         assert 'class="trigger-modal"' in html
-        assert 'muted' in html
-        assert '<video' in html
+        assert "muted" in html
+        assert "<video" in html
 
     def test_object_thumbnail_follows_proportion(self):
         html = self.image_object.as_html_thumbnail(editable=False)
-        expected_height = DEFAULT_OBJECT_THUMBNAIL_HEIGHT * self.image_object.yproportion
+        expected_height = (
+            DEFAULT_OBJECT_THUMBNAIL_HEIGHT * self.image_object.yproportion
+        )
         expected_width = DEFAULT_OBJECT_THUMBNAIL_WIDTH * self.image_object.xproportion
-        
+
         assert f'height="{expected_height}"' in html
         assert f'width="{expected_width}"' in html
-        assert 'href="/edit-object' not in html
-        assert 'href="/delete-content' not in html
+        assert reverse("edit-object") not in html
+        assert reverse("delete-content") not in html
 
     def test_object_thumbnail_can_be_edited(self):
         html = self.image_object.as_html_thumbnail(editable=True)
-        
-        edit_url = reverse('edit-object', query={'id': self.image_object.id})
-        delete_url = reverse('delete-content', 
-                           query={'content_type': 'object', 
-                                 'id': self.image_object.id})
-        
+
+        edit_url = reverse("edit-object", query={"id": self.image_object.id})
+        delete_url = reverse(
+            "delete-content",
+            query={"content_type": "object", "id": self.image_object.id},
+        )
+
         assert f'href="{edit_url}"' in html
         assert f'href="{delete_url}"' in html
 
     def test_object_in_use_cant_be_edited(self):
         # Create an artwork using this object to mark it as "in use"
         ArtworkFactory(augmented=self.image_object)
-        
+
         html = self.image_object.as_html_thumbnail(editable=True)
-        assert reverse('edit-object') not in html
-        assert reverse('delete-content') not in html
+        assert reverse("edit-object") not in html
+        assert reverse("delete-content") not in html
+
 
 class TestArtworkThumbnailGenerators(TestCase):
-    def test_thumbnail_generator(self):
-        # This is a placeholder for the actual test
-        self.assertTrue(True)
+    def setUp(self):
+        self.marker = MarkerFactory(
+            title="Test Marker", source="markers/test.png", author="Test Author"
+        )
+        self.object = ObjectFactory(
+            title="Test Object", source="objects/test.gif", author="Test Author"
+        )
+        self.artwork = ArtworkFactory(
+            title="Test Artwork", marker=self.marker, augmented=self.object
+        )
+
+    def test_artwork_thumbnail_not_editable(self):
+        html = self.artwork.as_html_thumbnail(editable=False)
+
+        # Should contain marker and object thumbnails
+        assert self.marker.source.url in html
+        assert self.object.source.url in html
+
+        # Should not contain edit/delete buttons
+        assert reverse("edit-artwork") not in html
+        assert reverse("delete-content") not in html
+        assert reverse("artwork-preview") not in html
+
+    def test_artwork_thumbnail_editable(self):
+        html = self.artwork.as_html_thumbnail(editable=True)
+
+        # Should contain marker and object thumbnails
+        assert self.marker.source.url in html
+        assert self.object.source.url in html
+
+        # Should contain edit/delete/preview buttons with correct URLs
+        edit_url = reverse("edit-artwork", query={"id": self.artwork.id})
+        delete_url = reverse(
+            "delete-content", query={"content_type": "artwork", "id": self.artwork.id}
+        )
+        preview_url = reverse("artwork-preview", query={"id": self.artwork.id})
+
+        assert f'href="{edit_url}"' in html
+        assert f'href="{delete_url}"' in html
+        assert f'href="{preview_url}"' in html
+
+    def test_artwork_in_use_cant_be_edited(self):
+        # Create an exhibit using this artwork to mark it as "in use"
+        exhibit = ExhibitFactory()
+        exhibit.artworks.add(self.artwork)
+
+        html = self.artwork.as_html_thumbnail(editable=True)
+
+        # Should not contain edit/delete/preview buttons
+        assert reverse("edit-artwork") not in html
+        assert reverse("delete-content") not in html
+        assert reverse("artwork-preview") not in html
+
 
 class TestExhibitThumbnailGenerators(TestCase):
-    def test_thumbnail_generator(self):
-        # This is a placeholder for the actual test
-        self.assertTrue(True)
+    def setUp(self):
+        self.exhibit = ExhibitFactory(name="Test Exhibit", slug="test-exhibit")
+        # Add a couple artworks to test the count
+        artwork1 = ArtworkFactory()
+        artwork2 = ArtworkFactory()
+        self.exhibit.artworks.add(artwork1, artwork2)
+
+    def test_exhibit_thumbnail_not_editable(self):
+        html = self.exhibit.as_html_thumbnail(editable=False)
+
+        # Check basic exhibit information
+        assert self.exhibit.name in html
+        assert self.exhibit.owner.user.username in html
+        assert self.exhibit.date in html
+        assert f"{self.exhibit.artworks_count} " in html
+
+        # Check links
+        assert f'href="/{self.exhibit.slug}/"' in html
+        assert 'class="gotoExb"' in html
+        assert reverse("exhibit-detail", query={"id": self.exhibit.id}) in html
+
+        # Should not contain edit/delete buttons
+        assert reverse("edit-exhibit") not in html
+        assert reverse("delete-content") not in html
+
+    def test_exhibit_thumbnail_editable(self):
+        html = self.exhibit.as_html_thumbnail(editable=True)
+
+        # Should contain all basic information
+        assert self.exhibit.name in html
+        assert self.exhibit.owner.user.username in html
+        assert self.exhibit.date in html
+        assert f"{self.exhibit.artworks_count} " in html
+
+        # Check links
+        assert f'href="/{self.exhibit.slug}/"' in html
+        assert reverse("exhibit-detail", query={"id": self.exhibit.id}) in html
+
+        # Should contain edit/delete buttons with correct URLs
+        edit_url = reverse("edit-exhibit", query={"id": self.exhibit.id})
+        delete_url = reverse(
+            "delete-content", query={"content_type": "exhibit", "id": self.exhibit.id}
+        )
+
+        assert f'href="{edit_url}"' in html
+        assert f'href="{delete_url}"' in html

--- a/src/users/jinja2/users/components/elements-modal.jinja2
+++ b/src/users/jinja2/users/components/elements-modal.jinja2
@@ -41,7 +41,7 @@
         function usedInExhibit(marker_id, object_id, exhibits_count, marker, augmented, element_id){
             let object_tag = ''
             let augmented_src = augmented.source 
-            if(augmented_src.split('.')[1] == 'mp4' || augmented_src.split('.')[1] == 'webm'){
+            if(augmented_src.endsWith('.mp4') || augmented_src.endsWith('.webm')){
                 object_tag = '<video muted autoplay loop id="' + object_id + '" class="trigger-erase artwork-content" data-elem-type="object" src="' + augmented_src + '"/></p>'
             } else {
                 object_tag = '<img id="' + object_id + '" class="trigger-erase artwork-content" data-elem-type="object" src="' + augmented_src + '"/></p>'

--- a/src/users/jinja2/users/components/item-list.jinja2
+++ b/src/users/jinja2/users/components/item-list.jinja2
@@ -66,9 +66,7 @@
 
             {% elif element_type == "artwork" %}
                 <div class="artwork-elements flex">
-                    {{ element.marker.as_html_thumbnail() | safe }}
-                    <div class="separator"></div>
-                    {{ element.augmented.as_html_thumbnail() | safe }} 
+                    {{ element.as_html_thumbnail() | safe }}
                     {% if editable == True %}
                         <a href="{{ url('edit-artwork') }}?id={{element.id}}" class="edit">edit</a>
                     {% endif %}

--- a/src/users/jinja2/users/components/item-list.jinja2
+++ b/src/users/jinja2/users/components/item-list.jinja2
@@ -14,51 +14,14 @@
 
             {% if element_type =="marker" or element_type=="object" %}
                 {%set canEdit_object%}
-                    {% if editable == True and not element.in_use%}
+                    {% if editable == True and not element.in_use %}
                         <a href="{{ url('edit-object') }}?id={{element.id}}" class="edit">edit</a>                
                     {% endif %}
                 {%endset%}
 
                 {%set canEdit_marker%}
-                    {% if editable == True and not element.in_use%}
+                    {% if editable == True and not element.in_use %}
                         <a href="{{ url('edit-marker') }}?id={{element.id}}" class="edit">edit</a>                
-                    {% endif %}
-                {%endset%}
-                
-                {%set loadImage_object_or_marker%}
-                    <img id="{{ element.id }}" title="{{ element.title }}" class="trigger-modal" data-elem-type="{{element_type}}" src="{{ element.source.url }}" height=50 width=50 >
-                {%endset%}
-
-                {%set load_object_video_or_image %}
-                    {% if element.is_video() %}
-                        <video id="{{ element.id }}" title="{{ element.title }}" class="trigger-modal" data-elem-type="{{element_type}}" src="{{ element.source.url }}" height="{{ element.yproportion * 50 }}" width="{{ element.xproportion * 50 }}" muted autoplay loop></video>
-                    {% else %} 
-                        {{loadImage_object_or_marker}}
-                    {% endif %}
-                {%endset%}
-           
-            {% elif element_type == "artwork" %}
-                {%set loadArtwork_Marker %}
-                    {% if element.title %}
-                        <img id="{{ element.id }}" title="{{ element.title }}" class="trigger-modal" data-elem-type="{{element_type}}" src="{{ element.marker.source.url }}" height="50" width="50">
-                    {% else %}
-                        <img id="{{ element.id }}" class="trigger-modal" data-elem-type="{{element_type}}" src="{{ element.marker.source.url }}" height="50" width="50">
-                    {% endif %}
-                {%endset%}
-
-                {%set loadArtwork_Object%}
-                    {% if element.augmented.source.url.endswith('.mp4') or element.augmented.source.url.endswith('.webm') %}
-                        {% if element.title %}
-                            <video id="{{ element.id }}" title="{{ element.title }}" class="trigger-modal" data-elem-type="{{element_type}}" src="{{ element.augmented.source.url }}" height="{{ element.augmented.yproportion * 50 }}" width="{{ element.augmented.xproportion * 50 }}" muted autoplay loop></video>
-                        {% else %}
-                            <video id="{{ element.id }}" class="trigger-modal" data-elem-type="{{element_type}}" src="{{ element.augmented.source.url }}" height="{{ element.augmented.yproportion * 50 }}" width="{{ element.augmented.xproportion * 50 }}" muted autoplay loop></video>
-                        {% endif %}
-                    {% else %}
-                        {% if element.title %}
-                            <img id="{{ element.id }}" title="{{ element.title }}" class="trigger-modal" data-elem-type="{{element_type}}" src="{{ element.augmented.source.url }}" height="{{ element.augmented.yproportion * 50 }}" width="{{ element.augmented.xproportion * 50 }}">
-                        {% else %}
-                            <img id="{{ element.id }}" class="trigger-modal" data-elem-type="{{element_type}}" src="{{ element.augmented.source.url }}" height="{{ element.augmented.yproportion * 50 }}" width="{{ element.augmented.xproportion * 50 }}">
-                        {% endif %}
                     {% endif %}
                 {%endset%}
 
@@ -92,20 +55,20 @@
             {# End of defining variables #}
 
             {% if element_type == "marker"%}
-                {{loadImage_object_or_marker}}
+                {{ element.as_html_thumbnail() | safe }}
                 {{canDelete_Entity}}
                 {{canEdit_marker}}
 
             {% elif element_type == "object" %}
-                {{load_object_video_or_image}}
+                {{ element.as_html_thumbnail() | safe }}
                 {{canDelete_Entity}}
                 {{canEdit_object}}
 
             {% elif element_type == "artwork" %}
                 <div class="artwork-elements flex">
-                    {{loadArtwork_Marker}}
+                    {{ element.marker.as_html_thumbnail() | safe }}
                     <div class="separator"></div>
-                    {{loadArtwork_Object}} 
+                    {{ element.augmented.as_html_thumbnail() | safe }} 
                     {% if editable == True %}
                         <a href="{{ url('edit-artwork') }}?id={{element.id}}" class="edit">edit</a>
                     {% endif %}

--- a/src/users/jinja2/users/components/item-list.jinja2
+++ b/src/users/jinja2/users/components/item-list.jinja2
@@ -33,8 +33,6 @@
                 {%endset%}   
 
                 {%set ExhibitInfo%}
-                    {#<p class="exhibit-name">{{element.name}}</p>#}
-                    {#<p class="exhibit-slug">TO_BE_FILLED_ON_SCRIPT<b>{{element.slug}}</b></p>#}
                     <p class="by">{{_("Created by ")}} <b>{{element.owner.user.username}}</b></p>
                     <p class="exbDate">{{element.date}}</p>
                     <p class="exhibit-about"><a href="{{url('exhibit-detail')}}?id={{element.id}}">{{element.artworks_count}} {{ _("Artwork(s)") }}</a></p>  
@@ -91,14 +89,5 @@
             {% endif %}
         </div>
     {% endfor %}
-    
-    <script src="https://unpkg.com/axios/dist/axios.min.js"></script> {# Importao axios (biblioteca para fazer request em api) #} 
-    <script>
-        $(".exhibit-slug").each(function(i,exhibit_slug){
-            highlight_part = "<b>" + exhibit_slug.innerHTML.split("<b>")[1]
-            site_url = window.location.protocol + "//" + window.location.host + "/"
-            exhibit_slug.innerHTML = site_url + highlight_part
-        }) 
 
-    </script>
 </section>

--- a/src/users/jinja2/users/components/item-list.jinja2
+++ b/src/users/jinja2/users/components/item-list.jinja2
@@ -12,20 +12,7 @@
             
             {# Begin defining variables #}
 
-            {% if element_type =="marker" or element_type=="object" %}
-                {%set canEdit_object%}
-                    {% if editable == True and not element.in_use %}
-                        <a href="{{ url('edit-object') }}?id={{element.id}}" class="edit">edit</a>                
-                    {% endif %}
-                {%endset%}
-
-                {%set canEdit_marker%}
-                    {% if editable == True and not element.in_use %}
-                        <a href="{{ url('edit-marker') }}?id={{element.id}}" class="edit">edit</a>                
-                    {% endif %}
-                {%endset%}
-
-            {% elif element_type == "exhibit" %}
+            {% if element_type == "exhibit" %}
                 {% set ExhibitTitle %}
                 <a href="{{url('exhibit-detail')}}?id={{element.id}}">
                     <h1 class="exhibit-name">{{element.name}}</h1>
@@ -53,14 +40,10 @@
             {# End of defining variables #}
 
             {% if element_type == "marker"%}
-                {{ element.as_html_thumbnail() | safe }}
-                {{canDelete_Entity}}
-                {{canEdit_marker}}
+                {{ element.as_html_thumbnail(editable=editable) | safe }}
 
             {% elif element_type == "object" %}
-                {{ element.as_html_thumbnail() | safe }}
-                {{canDelete_Entity}}
-                {{canEdit_object}}
+                {{ element.as_html_thumbnail(editable=editable) | safe }}
 
             {% elif element_type == "artwork" %}
                 <div class="artwork-elements flex">

--- a/src/users/jinja2/users/components/item-list.jinja2
+++ b/src/users/jinja2/users/components/item-list.jinja2
@@ -9,68 +9,7 @@
 {% endif %} 
     {% for element in repository_list %}
         <div id="{{ element_type }}-{{ element.id }}" class="repository-item">
-            
-            {# Begin defining variables #}
-
-            {% if element_type == "exhibit" %}
-                {% set ExhibitTitle %}
-                <a href="{{url('exhibit-detail')}}?id={{element.id}}">
-                    <h1 class="exhibit-name">{{element.name}}</h1>
-                </a>
-                {%endset%}   
-
-                {%set ExhibitInfo%}
-                    <p class="by">{{_("Created by ")}} <b>{{element.owner.user.username}}</b></p>
-                    <p class="exbDate">{{element.date}}</p>
-                    <p class="exhibit-about"><a href="{{url('exhibit-detail')}}?id={{element.id}}">{{element.artworks_count}} {{ _("Artwork(s)") }}</a></p>  
-                {%endset%}
-
-                {%set buttonSeeExhibition%}
-                    <a href="{{"/"+element.slug+"/"}}" class="gotoExb">{{ _("See this Exhibition") }}</a>
-                {%endset%}
-
-            {%endif%}
-
-            {%set canDelete_Entity%}
-                {% if deletable == True and not element.in_use %}
-                    <a href="{{ url('delete-content') }}?content_type={{element_type}}&id={{ element.id }}" onclick="return confirm('Are you sure you want to delete?')" class="delete">{{ _("Delete")}}</a>
-                {% endif %}
-            {%endset%}
-
-            {# End of defining variables #}
-
-            {% if element_type == "marker"%}
                 {{ element.as_html_thumbnail(editable=editable) | safe }}
-
-            {% elif element_type == "object" %}
-                {{ element.as_html_thumbnail(editable=editable) | safe }}
-
-            {% elif element_type == "artwork" %}
-                <div class="artwork-elements flex">
-                    {{ element.as_html_thumbnail() | safe }}
-                    {% if editable == True %}
-                        <a href="{{ url('edit-artwork') }}?id={{element.id}}" class="edit">edit</a>
-                    {% endif %}
-                    {{canDelete_Entity}}
-                    {% if preview == True %}
-                        <a href="{{ url('artwork-preview') }}?id={{ element.id }}" class="preview">{{_("Preview Artwork")}}</a>
-                    {% endif %}
-                </div>
-
-            {% else %}
-                {{ExhibitTitle}}            
-                <div>
-                    <div class="exhibit-info flex">
-                        {{ExhibitInfo}}
-                        {{buttonSeeExhibition}}
-                        {% if editable == True %}
-                            <a href="{{ url('edit-exhibit') }}?id={{element.id}}" class="edit">{{ _("Edit")}}</a>
-                        {% endif %}
-                        {{canDelete_Entity}}
-                    </div>
-                </div>
-            {% endif %}
         </div>
     {% endfor %}
-
 </section>

--- a/src/users/jinja2/users/components/item-list.jinja2
+++ b/src/users/jinja2/users/components/item-list.jinja2
@@ -30,7 +30,7 @@
                 {%endset%}
 
                 {%set load_object_video_or_image %}
-                    {% if element.source.url.split('.')[1] == "mp4" or element.source.url.split('.')[1] == "webm" %}
+                    {% if element.is_video() %}
                         <video id="{{ element.id }}" title="{{ element.title }}" class="trigger-modal" data-elem-type="{{element_type}}" src="{{ element.source.url }}" height="{{ element.yproportion * 50 }}" width="{{ element.xproportion * 50 }}" muted autoplay loop></video>
                     {% else %} 
                         {{loadImage_object_or_marker}}

--- a/src/users/views.py
+++ b/src/users/views.py
@@ -227,7 +227,7 @@ def create_exhibit(request):
     else:
         form = ExhibitForm()
 
-    artworks = Artwork.objects.all().order_by("-id")
+    artworks = Artwork.objects.filter(author=request.user.profile).order_by("-id")
 
     return render(
         request,

--- a/uv.lock
+++ b/uv.lock
@@ -332,6 +332,15 @@ wheels = [
 ]
 
 [[package]]
+name = "fast-html"
+version = "1.0.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/2b/9cc1c386fdf55d04c1f1346ec869eda28bd2da4e10f5514948b892b5f22a/fast_html-1.0.11.tar.gz", hash = "sha256:6eb8ed1f569f8e08b8af68e9dcef27a3a3e6593ac01cb3bad5647dfa9e274586", size = 8128 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/3c/7059f6357f34ef95dff955f0f14b6eba10346cbb137186e4ff3f2069ecbc/fast_html-1.0.11-py3-none-any.whl", hash = "sha256:3804fa9166ac4b1b9d7ad1e8831430efd082d1657a967c2c1baa4e58cfeb53e3", size = 8991 },
+]
+
+[[package]]
 name = "gevent"
 version = "24.11.1"
 source = { registry = "https://pypi.org/simple" }
@@ -427,7 +436,7 @@ wheels = [
 
 [[package]]
 name = "jandig"
-version = "1.5.0"
+version = "1.5.1"
 source = { virtual = "." }
 dependencies = [
     { name = "babel" },
@@ -441,6 +450,7 @@ dependencies = [
     { name = "djangorestframework" },
     { name = "djangorestframework-simplejwt" },
     { name = "drf-nested-routers" },
+    { name = "fast-html" },
     { name = "gevent" },
     { name = "gunicorn" },
     { name = "jinja2" },
@@ -480,6 +490,7 @@ requires-dist = [
     { name = "djangorestframework", specifier = "~=3.15" },
     { name = "djangorestframework-simplejwt", specifier = ">=5.5.0" },
     { name = "drf-nested-routers", specifier = "~=0.94" },
+    { name = "fast-html", specifier = ">=1.0.11" },
     { name = "gevent", specifier = "~=24.11" },
     { name = "gunicorn", specifier = "~=23.0" },
     { name = "jinja2", specifier = "~=3.1" },


### PR DESCRIPTION
## Description

Moved business logic from HTML templating with Jinja2 to Python


## General tasks performed
* Replaced all jinja ifs on item-list component with direct python methods
* Fixed redirect on see_all page
* Fixed tagged images release
* Fixed elements modal for videos
* Fixed slow query on create exhibit endpoint

### Have you confirmed the application builds locally without error? See [here](https://github.com/memeLab/Jandig#running).
- [x] Yes