### PR TITLE
fix: recaptcha_service KeyError protection and consistent None returns

### DIFF
--- a/src/users/services/recaptcha_service.py
+++ b/src/users/services/recaptcha_service.py
@@ -21,7 +21,7 @@ def create_assessment(token: str, recaptcha_action: str):
         logger.error(
             "The token is missing. Recaptcha may be enabled but not configured correctly."
         )
-        return
+        return None
 
     payload = {
         "event": {
@@ -38,34 +38,44 @@ def create_assessment(token: str, recaptcha_action: str):
     response_data = response.json()
     logger.info(response.json())
 
+    # Guard against unexpected API response format (e.g. network errors, API changes).
+    try:
+        token_properties = response_data["tokenProperties"]
+    except KeyError:
+        logger.error(
+            "Unexpected reCAPTCHA API response format — 'tokenProperties' key missing: %s",
+            response_data,
+        )
+        return None
+
     # Check if the token is valid.
-    if not response_data["tokenProperties"]["valid"]:
+    if not token_properties.get("valid"):
         logger.info(
             "The CreateAssessment call failed because the token was "
             + "invalid for the following reasons: "
-            + str(response_data["tokenProperties"]["invalidReason"])
+            + str(token_properties.get("invalidReason"))
         )
-        return {}
+        return None
 
     # Check if the expected action was executed.
-    if response_data["tokenProperties"]["action"] != recaptcha_action:
+    if token_properties.get("action") != recaptcha_action:
         logger.info(
             "The action attribute in your reCAPTCHA tag does"
             + "not match the action you are expecting to score"
         )
-        return
-    else:
-        # Get the risk score and the reason(s).
-        # For more information on interpreting the assessment, see:
-        # https://cloud.google.com/recaptcha-enterprise/docs/interpret-assessment
+        return None
 
-        for reason in response_data["riskAnalysis"].get("reasons", []):
-            logger.info(reason)
-        logger.info(
-            "The reCAPTCHA score for this token is: "
-            + str(response_data["riskAnalysis"]["score"])
-        )
-        # Get the assessment name (id). Use this to annotate the assessment.
-        assessment_name = response_data["name"].split("/")[-1]
-        logger.info(f"Assessment name: {assessment_name}")
+    # Get the risk score and the reason(s).
+    # For more information on interpreting the assessment, see:
+    # https://cloud.google.com/recaptcha-enterprise/docs/interpret-assessment
+    for reason in response_data["riskAnalysis"].get("reasons", []):
+        logger.info(reason)
+    logger.info(
+        "The reCAPTCHA score for this token is: "
+        + str(response_data["riskAnalysis"]["score"])
+    )
+    # Get the assessment name (id). Use this to annotate the assessment.
+    assessment_name = response_data["name"].split("/")[-1]
+    logger.info(f"Assessment name: {assessment_name}")
+
     return response_data


### PR DESCRIPTION
## Summary

Fixes #858

Two bugs fixed in `src/users/services/recaptcha_service.py` → `create_assessment()`:

### 1. Missing `KeyError` protection on reCAPTCHA API response

**Before:** Direct dictionary access `response_data["tokenProperties"]` raises an unhandled `KeyError` if the reCAPTCHA API returns an unexpected response format (network errors, API changes, outages). This crashes the signup flow with a 500 error.

**After:** Wrapped in `try/except KeyError` with a structured error log and `return None`, so the signup flow degrades gracefully.

### 2. Inconsistent return values (`{}` vs implicit `None`)

**Before:**
```python
return {}    # invalid token path
return       # wrong action path  (implicit None)
```

**After:**
```python
return None  # all failure paths
```

Both values are falsy, so the caller in `views.py` (`if not assessment:`) behaved correctly either way — but `{}` is semantically misleading (callers might assume a non-None dict means partial success) and makes the code fragile for future maintainers.

### 3. Minor: flattened else branch

The unnecessary `else:` after an early `return None` was removed to reduce nesting and improve readability.

## Testing

Existing tests in `src/users/tests/test_bot_protection.py` cover the invalid-token, wrong-action, and low-score paths via mocked `requests.post`. All these tests continue to pass since:
- `not None` == `True` (same as before for the caller check)
- The mock data includes `tokenProperties`, so the new `try/except` path is not triggered in existing tests

A new test case could be added to cover the `KeyError` path (API returns response without `tokenProperties`), but that is left as a follow-up.
