### PR TITLE
fix(core): guard post_delete Object audio_description cleanup on None

### DIFF
--- a/src/core/models.py
+++ b/src/core/models.py
@@ -608,6 +608,12 @@ def remove_source_file(sender, instance, **kwargs):
         instance.source.delete(False)
     if isinstance(instance, Object):
         instance.source.delete(False)
-        instance.audio_description.delete(False)
+        # audio_description is FileField(null=True, blank=True). An Object
+        # created without one can surface as None here (or as a FieldFile
+        # with an empty name), and calling .delete() on that raises
+        # AttributeError and aborts the rest of the cleanup, orphaning the
+        # source file we just removed. See #849.
+        if instance.audio_description:
+            instance.audio_description.delete(False)
     if isinstance(instance, Sound):
         instance.file.delete(False)


### PR DESCRIPTION
### Problem

`Object.audio_description` is declared as
`FileField(null=True, blank=True)`, so an `Object` created without an
audio description can surface as `None` in the `post_delete` signal
receiver. The current code unconditionally dereferences it:

```python
if isinstance(instance, Object):
    instance.source.delete(False)
    instance.audio_description.delete(False)   # AttributeError if None
```

When that happens, `remove_source_file` bails out of the cleanup
halfway through. The source file we just removed ends up orphaned on
disk with no matching row, which is exactly the state the signal
receiver is there to prevent. See #849.

### Fix

Gate the `delete` call on the field being truthy. Django's `FieldFile`
is already truthy only when a file is associated, so this also covers
the "empty `FieldFile`" case cleanly.

```diff
  if isinstance(instance, Object):
      instance.source.delete(False)
-     instance.audio_description.delete(False)
+     if instance.audio_description:
+         instance.audio_description.delete(False)
```

No change to the happy path or to the `Marker` / `Sound` branches.

Fixes #849
