### PR TITLE
fix(blog): correct inverted last_page context value in blog_index

### DIFF
--- a/src/blog/views.py
+++ b/src/blog/views.py
@@ -28,7 +28,11 @@ def blog_index(request):
         "next_page_number": page_number + 1,
         "posts": posts,
         "PREVIEW_SIZE": PREVIEW_SIZE,
-        "last_page": page.has_previous(),
+        # `last_page` should be True once the user has reached the final
+        # page (no more posts to load). `page.has_previous()` returns True
+        # for every page except the first, so the old value was inverted
+        # and the feed appeared to end on page 2. See #857.
+        "last_page": not page.has_next(),
         "total_pages": paginator.num_pages,
         "page_url": "/memories/",
         "blog_categories": Category.objects.all(),


### PR DESCRIPTION
### Problem

`blog_index` in `src/blog/views.py` populates `last_page` in the
template context with `page.has_previous()`:

```python
context = {
    ...
    "last_page": page.has_previous(),
    ...
}
```

`Paginator.Page.has_previous()` returns `True` whenever there are
pages **before** the current one — i.e., for every page except
page 1. The variable name promises the opposite: `last_page` should
be `True` only when the reader has reached the final page.

Downstream templates use `last_page` to terminate the "load more"
cycle / show an end-of-feed marker. With the old value the feed
appeared to end as soon as the reader clicked past page 1, regardless
of how many posts actually remained. #857.

### Fix

Use the semantic opposite that actually matches the variable name:

```diff
- "last_page": page.has_previous(),
+ "last_page": not page.has_next(),
```

`page.has_next()` returns `False` only on the final page, so
`not page.has_next()` is `True` exactly when the reader has reached
the end of the feed.

Fixes #857
