### PR TITLE
fix(blog): resolve Post.get_absolute_url via reverse() so it does not reference missing slug

### DIFF
--- a/src/blog/models.py
+++ b/src/blog/models.py
@@ -1,5 +1,6 @@
 from django.core.files.storage import default_storage
 from django.db import models
+from django.urls import reverse
 from django_extensions.db.models import TimeStampedModel
 from django_prose_editor.fields import ProseEditorField
 
@@ -91,4 +92,9 @@ class Post(TimeStampedModel):
         return self.title
 
     def get_absolute_url(self):
-        return f"/memories/{self.slug}/"
+        # Post has no slug field; the only detail route that exists is
+        # `blog/post/<int:pk>/` (registered as `post_detail`). The previous
+        # `f"/memories/{self.slug}/"` raised AttributeError on every call.
+        # Use reverse() so get_absolute_url() stays correct if the URL
+        # conf is ever renamed or remounted. See #855.
+        return reverse("post_detail", kwargs={"pk": self.pk})


### PR DESCRIPTION
## What

`Post.get_absolute_url()` in `src/blog/models.py` returns `f"/memories/{self.slug}/"`, but the `Post` model has no `slug` field. The primary key is an `id = models.BigAutoField(primary_key=True)` and the class body only defines `title`, `status`, `author`, `excerpt`, `categories`, `images`, and `formatted_body`. Any call to `post.get_absolute_url()` raises `AttributeError: 'Post' object has no attribute 'slug'`.

This fires from:
- Django admin's "View on site" button
- any feed generator that calls `get_absolute_url` on a post
- any template that renders `{{ post.get_absolute_url }}` or `{% url post %}`-style tags

## Fix

Use `django.urls.reverse()` against the existing route:

```python
# src/blog/urls.py
path("post/<int:pk>/", views.post_detail, name="post_detail"),
```

so `get_absolute_url` becomes:

```python
def get_absolute_url(self):
    return reverse("post_detail", kwargs={"pk": self.pk})
```

`reverse()` also means the method stays correct if the URL is ever renamed or remounted under a different prefix — we don't hard-code `/memories/` or `/blog/post/` anywhere.

## Why not add a slug field instead

Adding a `slug` would change URLs (breaking existing memory links), require a data migration to backfill slugs for every existing post, and touch `urls.py` / `views.py` / the detail template. The one-line `reverse()` fix restores the method to what the rest of the codebase already expects.

Fixes #855