### PR TITLE
fix(blog): return 404 from post_detail when pk does not match a post

### DIFF
--- a/src/blog/views.py
+++ b/src/blog/views.py
@@ -1,5 +1,5 @@
 from django.core.paginator import Paginator
-from django.shortcuts import render
+from django.shortcuts import get_object_or_404, render
 
 from blog.models import Category, Clipping, Post, PostStatus
 
@@ -40,7 +40,10 @@ def blog_index(request):
 
 
 def post_detail(request, pk):
-    post = Post.objects.prefetch_related("images", "categories").get(pk=pk)
+    post = get_object_or_404(
+        Post.objects.prefetch_related("images", "categories"),
+        pk=pk,
+    )
 
     context = {"post": post, "images": post.images.all()}
 


### PR DESCRIPTION
## What

`post_detail` in `src/blog/views.py` called:

```python
def post_detail(request, pk):
    post = Post.objects.prefetch_related("images", "categories").get(pk=pk)
    ...
```

`QuerySet.get(pk=pk)` raises `Post.DoesNotExist` when the pk does not match a row. The view did not catch it, so Django's default handler turned every missing-post request into an HTTP 500 Internal Server Error.

The route `blog/post/<int:pk>/` is public, so any stale permalink, crawler, or user who types a pk that has since been deleted triggers a 500. On top of being wrong from an HTTP-semantics angle (it should be 404), it also pollutes Sentry / the server's error log with noise that masks real 500s.

## Fix

Swap `.get(pk=pk)` for `django.shortcuts.get_object_or_404` against the same prefetched queryset:

```python
from django.shortcuts import get_object_or_404, render

def post_detail(request, pk):
    post = get_object_or_404(
        Post.objects.prefetch_related("images", "categories"),
        pk=pk,
    )
    ...
```

`get_object_or_404` delegates to the same `.get()` call under the hood, so behaviour for any pk that does resolve is identical (same prefetching, same queryset). The only observable change is that a missing pk now returns a clean 404 Not Found.

Fixes #856