### PR TITLE
fix(core): stop filtering Sound queryset by ObjectExtensions.GLB in ArtworkForm

### DIFF
--- a/src/core/forms.py
+++ b/src/core/forms.py
@@ -184,7 +184,7 @@ class ArtworkForm(forms.ModelForm):
         widget=RangeInput(attrs={"class": "slider", "step": "0.1"}),
     )
     selected_sound = forms.ModelChoiceField(
-        queryset=Sound.objects.exclude(file_extension=ObjectExtensions.GLB),
+        queryset=Sound.objects.all(),
         required=False,
         widget=forms.Select(attrs={"class": "form-control"}),
     )


### PR DESCRIPTION
## What

`ArtworkForm.selected_sound` in `src/core/forms.py` declared its queryset as:

```python
selected_sound = forms.ModelChoiceField(
    queryset=Sound.objects.exclude(file_extension=ObjectExtensions.GLB),
    required=False,
    widget=forms.Select(attrs={"class": "form-control"}),
)
```

`ObjectExtensions` is the enum for 3D object files on the `Object` model (`GLB = "glb"`). `Sound` rows are populated by `SoundForm` with `file_extension` in `{"mp3", "ogg", "wav"}`. No `Sound` instance ever has `file_extension == "glb"`, so the `exclude()` is a no-op today — but it also means the code is silently referencing the wrong enum for the wrong model.

Compare with `UploadObjectForm.selected_sound` in the same file, which uses `Sound.objects.all()`. The two forms are pointing at the same "pick one of my sounds" dropdown and should behave identically.

## Why it matters

Right now it's a latent bug with no runtime effect. It becomes a real bug the moment anyone:

- renames `ObjectExtensions.GLB` to another value (for example if GLTF support is added and values are reshuffled),
- moves the constant or reuses the name,
- or adds a `"glb"` extension to `SoundExtensions` for some reason.

Any of those quietly start filtering real rows out of the artwork form's sound picker, and the mismatch between `ArtworkForm` and `UploadObjectForm` would make it extremely easy to miss.

## Fix

Drop the `exclude()`:

```python
selected_sound = forms.ModelChoiceField(
    queryset=Sound.objects.all(),
    required=False,
    widget=forms.Select(attrs={"class": "form-control"}),
)
```

Observable behaviour is unchanged (the old filter matched zero rows). `ArtworkForm` now agrees with `UploadObjectForm` on what "all sounds" means.

Fixes #848