### PR TITLE
fix(users): return 404 from profile view when ?user= points at a missing or non-int id

### DIFF
--- a/src/users/views.py
+++ b/src/users/views.py
@@ -11,7 +11,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.views import PasswordResetView
 from django.contrib.messages.views import SuccessMessageMixin
 from django.http import Http404, JsonResponse
-from django.shortcuts import redirect, render
+from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse_lazy
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.http import require_http_methods
@@ -88,22 +88,34 @@ class ResetPasswordView(SuccessMessageMixin, PasswordResetView):
 @login_required
 @require_http_methods(["GET"])
 def profile(request):
-    user = request.GET.get("user")
+    user_param = request.GET.get("user")
 
-    if not user:
+    if not user_param:
         user = request.user
+    else:
+        # ?user=... refers to a User primary key. Anything else is a bad
+        # link, not a server error, so coerce + 404 instead of letting the
+        # ORM raise ValueError / DoesNotExist up into a 500.
+        try:
+            user_id = int(user_param)
+        except (TypeError, ValueError):
+            raise Http404
+        user = get_object_or_404(User, pk=user_id)
 
-    profile = Profile.objects.prefetch_related(
-        "exhibits__artworks",
-        "artworks__exhibits",
-        "artworks__marker",
-        "artworks__augmented",
-        "markers__artworks",
-        "ar_objects__artworks",
-        "sounds__artworks",
-        "sounds__ar_objects",
-        "sounds__exhibits",
-    ).get(user=user)
+    profile = get_object_or_404(
+        Profile.objects.prefetch_related(
+            "exhibits__artworks",
+            "artworks__exhibits",
+            "artworks__marker",
+            "artworks__augmented",
+            "markers__artworks",
+            "ar_objects__artworks",
+            "sounds__artworks",
+            "sounds__ar_objects",
+            "sounds__exhibits",
+        ),
+        user=user,
+    )
 
     ar_exhibits = (
         profile.exhibits.filter(exhibit_type=ExhibitTypes.AR).all().order_by("-created")


### PR DESCRIPTION
## What

`profile()` in `src/users/views.py` read `?user=` straight off `request.GET` and fed the raw string to the ORM:

```python
def profile(request):
    user = request.GET.get("user")
    if not user:
        user = request.user
    profile = Profile.objects.prefetch_related(...).get(user=user)
```

`Profile.user` is a `ForeignKey` to the `User` PK (integer). That raw string becomes a 500 in two separate ways:

1. Non-numeric `?user=` values (e.g. `?user=abc`, `?user=1'or'1`, `?user=` with odd characters) are passed to the DB layer. PostgreSQL rejects them; Django surfaces the resulting `ValueError`/`DataError` as an uncaught 500.
2. Numeric but unknown values (e.g. `?user=99999`) pass the cast but raise `Profile.DoesNotExist`, which Django again turns into a 500.

Both cases should be 404s. Because this view is `@login_required` and reachable from authenticated user-browsing, any stale link or crawler probing with a guessed id pollutes the error tracker.

## Fix

- Parse `?user=` to `int` and `Http404` if it does not coerce.
- Look up the referenced `User` via `get_object_or_404(User, pk=user_id)`.
- Wrap the `Profile` prefetch in `get_object_or_404` on the same queryset, so a missing `Profile` returns 404 instead of 500.
- Self-view path (no `?user=` param, just `request.user`) is unchanged.

```python
user_param = request.GET.get("user")

if not user_param:
    user = request.user
else:
    try:
        user_id = int(user_param)
    except (TypeError, ValueError):
        raise Http404
    user = get_object_or_404(User, pk=user_id)

profile = get_object_or_404(
    Profile.objects.prefetch_related(...),
    user=user,
)
```

`Http404` is already imported in this module (used by `edit_password`). `get_object_or_404` is a new import from `django.shortcuts`.

Fixes #854