### PR TITLE
fix(core): use "seeall" not "seeall:" as the context key in related_content

### DIFF
--- a/src/core/views/views.py
+++ b/src/core/views/views.py
@@ -660,7 +660,7 @@ def related_content(request):
             .distinct()
         )
 
-        ctx = {"artworks": artworks, "exhibits": exhibits, "seeall:": False}
+        ctx = {"artworks": artworks, "exhibits": exhibits, "seeall": False}
 
     elif element_type == "artwork":
         element = Artwork.objects.prefetch_related(
@@ -669,7 +669,7 @@ def related_content(request):
 
         exhibits = element.exhibits.all()
 
-        ctx = {"exhibits": exhibits, "seeall:": False}
+        ctx = {"exhibits": exhibits, "seeall": False}
 
     elif element_type == "sound":
         element = Sound.objects.prefetch_related(


### PR DESCRIPTION
## What

`related_content` in `src/core/views/views.py` builds three context dicts, one for each element type. Two of them have a stray colon in the key name:

```python
# object / marker branch
ctx = {"artworks": artworks, "exhibits": exhibits, "seeall:": False}

# artwork branch
ctx = {"exhibits": exhibits, "seeall:": False}

# sound branch (correct)
ctx = {..., "seeall": False}
```

`core/collection.jinja2` reads `seeall` (no colon) to decide whether to render the "See all" link. Because the key has a trailing `:`, the template never finds `seeall` for the `object`, `marker`, or `artwork` branches and falls back to whatever Jinja does with an undefined variable. The sound branch is the odd one out that happens to work, which is what makes the typo obvious.

Per `#850`.

## Fix

One-line rename on both offending dict keys:

```python
ctx = {"artworks": artworks, "exhibits": exhibits, "seeall": False}
ctx = {"exhibits": exhibits, "seeall": False}
```

No other call sites reference the key, and the existing `seeall` reads in `collection`, `see_all`, and `related_content` (sound branch) stay correct.

## Verified

- `grep -n '"seeall' src/core/views/views.py` before: 5 matches, 2 with the colon, 3 correct.
- After the fix: 5 matches, 0 with the colon, 5 correct.
- `grep` on the collection template confirms the template only references `seeall` (no colon).

Fixes #850