### PR TITLE
fix(core): return 404 from marker_preview when ?id= is missing, non-int, or unknown

### DIFF
--- a/src/core/views/views.py
+++ b/src/core/views/views.py
@@ -189,7 +189,14 @@ def object_upload(request):
 @require_http_methods(["GET"])
 def marker_preview(request):
     marker_id = request.GET.get("id")
-    marker = Marker.objects.get(id=marker_id)
+    # ?id= comes off the query string as either None or a raw string.
+    # Marker.id is an integer PK, so coerce + 404 instead of letting a
+    # missing/garbage value surface as ValueError or DoesNotExist.
+    try:
+        marker_id = int(marker_id)
+    except (TypeError, ValueError):
+        raise Http404
+    marker = get_object_or_404(Marker, id=marker_id)
     artwork = {
         "marker": marker,
         "augmented": marker,


### PR DESCRIPTION
## What

`marker_preview` in `src/core/views/views.py` calls:

```python
@require_http_methods(["GET"])
def marker_preview(request):
    marker_id = request.GET.get("id")
    marker = Marker.objects.get(id=marker_id)
    ...
```

`marker_id` is whatever came off the query string: `None`, a numeric string, or arbitrary junk. `Marker.objects.get(id=marker_id)` turns every non-happy-path into an HTTP 500 via Django's default handler:

1. `?id` missing → `marker_id is None` → ORM issues `id IS NULL` → `DoesNotExist`.
2. `?id=abc` (or any non-numeric junk bots send) → DB driver rejects the integer cast → `ValueError` / `DataError`.
3. `?id=99999` (deleted / never existed) → `DoesNotExist`.

All three should be 404s, not server errors. The `/marker/preview` endpoint is unauthenticated and reachable from marker thumbnails in the collection UI, so stale links and crawlers reliably log 500s in the error tracker, drowning real bugs.

## Fix

Same pattern already used for `exhibit_detail` and `related_content` in this module: coerce the id to `int` first (`Http404` on failure), then fetch via `get_object_or_404`.

```python
marker_id = request.GET.get("id")
try:
    marker_id = int(marker_id)
except (TypeError, ValueError):
    raise Http404
marker = get_object_or_404(Marker, id=marker_id)
```

`get_object_or_404` and `Http404` are already imported from `django.shortcuts` / `django.http` at the top of the file; no new imports needed. Behaviour for a valid, existing marker id is unchanged.

Fixes #847