### PR TITLE
fix(core): validate and 404 before touching edit_marker / edit_object payloads

### DIFF
--- a/src/core/views/views.py
+++ b/src/core/views/views.py
@@ -226,7 +226,14 @@ def marker_upload(request):
 @login_required
 def edit_marker(request):
     index = request.GET.get("id", "-1")
-    model = Marker.objects.get(id=index)
+    try:
+        index = int(index)
+    except (TypeError, ValueError):
+        raise Http404
+    model = get_object_or_404(Marker, id=index)
+
+    if model.owner != request.user.profile:
+        raise Http404
 
     model_data = {
         "source": model.source,
@@ -235,9 +242,6 @@ def edit_marker(request):
         "patt": model.patt,
         "title": model.title,
     }
-
-    if not model or model.owner != Profile.objects.get(user=request.user):
-        raise Http404
 
     if request.method == "POST":
         form = UploadMarkerForm(request.POST, request.FILES, instance=model)
@@ -263,7 +267,14 @@ def edit_marker(request):
 @login_required
 def edit_object(request):
     index = request.GET.get("id", "-1")
-    model = Object.objects.get(id=index)
+    try:
+        index = int(index)
+    except (TypeError, ValueError):
+        raise Http404
+    model = get_object_or_404(Object, id=index)
+
+    if model.owner != request.user.profile:
+        raise Http404
 
     model_data = {
         "source": model.source,
@@ -272,8 +283,6 @@ def edit_object(request):
         "title": model.title,
         "thumbnail": model.thumbnail,
     }
-    if not model or model.owner != Profile.objects.get(user=request.user):
-        raise Http404
 
     if request.method == "POST":
         form = UploadObjectForm(request.POST, request.FILES, instance=model)


### PR DESCRIPTION
## What

Both `edit_marker` and `edit_object` in `src/core/views/views.py` had the same bug-shaped logic:

```python
def edit_marker(request):
    index = request.GET.get("id", "-1")
    model = Marker.objects.get(id=index)

    model_data = {
        "source": model.source,
        ...
    }

    if not model or model.owner != Profile.objects.get(user=request.user):
        raise Http404
```

Three things are wrong:

1. **500 on unknown/garbage id.** `Marker.objects.get(id=index)` raises `DoesNotExist` for unknown ids and `ValueError` / `DataError` for non-numeric values. The default `"-1"` falls back to a DB query that returns nothing and again raises `DoesNotExist`. All three surface as HTTP 500.
2. **`model_data` built before the permission check.** The dict is filled from the row's fields (`source`, `created`, `author`, `patt`, `title`) before we know if the requester owns the row. Today the data never escapes because `Http404` is raised two lines later, but the ordering is exactly the kind that breaks the moment someone adds logging, a metric, or serialisation above the guard.
3. **`if not model`** is dead code: `.get()` either returns an instance or raises, so the sentinel branch can never fire.

## Fix

- Coerce `index` to `int` first, `Http404` on failure.
- Fetch with `get_object_or_404` so unknown id → 404.
- Do the `owner != request.user.profile` check *before* building `model_data`.
- Drop the dead `if not model` branch.

`edit_object` gets the same treatment (same bug in the same shape).

```python
def edit_marker(request):
    index = request.GET.get("id", "-1")
    try:
        index = int(index)
    except (TypeError, ValueError):
        raise Http404
    model = get_object_or_404(Marker, id=index)
    if model.owner != request.user.profile:
        raise Http404
    model_data = { ... }
```

Matches the pattern already used by `create_or_edit_exhibit` and `edit_artwork` further down this file.

Fixes #846