### PR TITLE
fix(core): make me_hotsite url non-capturing so the view does not take a dummy arg

### DIFF
--- a/src/core/urls.py
+++ b/src/core/urls.py
@@ -63,7 +63,7 @@ urlpatterns = [
     path("sounds/upload/", sound_upload, name="sound-upload"),
     path("elements/", get_element, name="get-element"),
     re_path(
-        r"^(me|ME)\/?$",
+        r"^(?:me|ME)\/?$",
         me_hotsite,
         name="mitologia-extendida",
     ),

--- a/src/core/views/static_views.py
+++ b/src/core/views/static_views.py
@@ -19,7 +19,7 @@ def health_check(_):
     return JsonResponse({"status": "ok"}, status=200)
 
 
-def me_hotsite(request, _):
+def me_hotsite(request):
     return render(request, "core/ME/hotsite.html", {})
 
 


### PR DESCRIPTION
## What

`core/urls.py` routes `/me/` and `/ME/` to `me_hotsite` via a `re_path` with a capturing group:

```python
re_path(
    r"^(me|ME)\/?$",
    me_hotsite,
    name="mitologia-extendida",
),
```

Because the group is capturing, Django passes the matched string (`"me"` or `"ME"`) as a positional arg to the view. The view swallows it with an underscore:

```python
def me_hotsite(request, _):
    return render(request, "core/ME/hotsite.html", {})
```

The captured value is never used. The fragility is the signature: anyone cleaning up the URL (dropping the capture, converting to `(?:me|ME)`, switching to `path(...)`, or reusing `me_hotsite` from a pattern without capture) immediately breaks the view with `TypeError: me_hotsite() missing 1 required positional argument: '_'`. The two sides are coupled for no functional reason.

## Fix

- `urls.py`: capture → non-capturing group `(?:me|ME)`.
- `static_views.py`: drop the unused second arg from the view signature.

```python
# urls.py
re_path(r"^(?:me|ME)\/?$", me_hotsite, name="mitologia-extendida"),

# static_views.py
def me_hotsite(request):
    return render(request, "core/ME/hotsite.html", {})
```

Both `/me/` and `/ME/` continue to match and render the same page. The captured string was never consulted, so no behaviour changes.

Fixes #851