### PR TITLE
fix(core): advertise the marker preview data URI as image/png, not image/jpeg

### DIFF
--- a/src/core/views/api_views.py
+++ b/src/core/views/api_views.py
@@ -61,7 +61,7 @@ class MarkerGeneratorAPIView(APIView):
             base64_encoded_result_str = base64_encoded_result_bytes.decode("ascii")
 
             # Create an HTML image tag with the base64 data
-            transformed_image = f"data:image/jpeg;base64,{base64_encoded_result_str}"
+            transformed_image = f"data:image/png;base64,{base64_encoded_result_str}"
 
             return HttpResponse(
                 render(


### PR DESCRIPTION
## What

`MarkerGeneratorAPIView.post()` in `src/core/views/api_views.py` encodes the generated marker as PNG:

```python
transformed_image.save(in_mem_file, format="PNG")
```

but wraps the bytes in a `data:` URI that lies about the type:

```python
transformed_image = f"data:image/jpeg;base64,{base64_encoded_result_str}"
```

## Why it matters

Chromium and Firefox ignore the declared MIME and sniff the bytes, so the preview shows correctly in the browser UI. But anything that *trusts* the label breaks:

- **"Save image as…"** picks a `.jpg` extension for what's really a PNG (transparent background included). Re-uploading that file anywhere that validates extension↔content consistency fails.
- **CSP `img-src`** evaluators keyed off the type hint (e.g. some CDN image-proxy rules) reject it.
- **Headless/strict renderers** in tests or downstream tooling that decode based on the MIME choke on a JPEG header that isn't there.
- **Any consumer that sniffs the MIME from the data URI prefix** silently gets the wrong answer.

Zero of these matter for Chrome preview. All of them matter for the "use the marker image elsewhere" paths.

Per #852.

## Fix

One-character fix: swap `jpeg` → `png` in the prefix so it matches `format="PNG"` above:

```python
transformed_image = f"data:image/png;base64,{base64_encoded_result_str}"
```

The other direction (switching `format="PNG"` to `format="JPEG"`) would lose the transparency that PNG encodes — the explicit `format="PNG"` above makes the intent obvious.

Fixes #852