### PR TITLE
Add .PHONY declarations to Makefile targets (#883)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 RUNNING_CONTAINER := $(shell docker compose ps --services --filter "status=running" | grep django )
 
+.PHONY: test test-ui test-all lint check migrations migrate collectstatic gen translate_es translate_pt
+
 test:
 	@if [ -n "${RUNNING_CONTAINER}" ]; then \
 		docker compose exec django pytest src/core src/users src/blog; \


### PR DESCRIPTION
Add `.PHONY` declarations to all Makefile targets — prevents conflicts with same-named files and skips unnecessary stat checks. Per @pablodiegoss's review on the issue, this is the only legitimate part of the original report.

Closes #883

https://claude.ai/code/session_01XC1THLWgnGXGf5wgRhdyvB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XC1THLWgnGXGf5wgRhdyvB)_