### PR TITLE
Fix inverted last_page logic in blog_index (#857)

### DIFF
--- a/src/blog/views.py
+++ b/src/blog/views.py
@@ -28,7 +28,7 @@ def blog_index(request):
         "next_page_number": page_number + 1,
         "posts": posts,
         "PREVIEW_SIZE": PREVIEW_SIZE,
-        "last_page": page.has_previous(),
+        "last_page": not page.has_next(),
         "total_pages": paginator.num_pages,
         "page_url": "/memories/",
         "blog_categories": Category.objects.all(),


### PR DESCRIPTION
`page.has_previous()` returns `True` for every page except the first, so using it as a `last_page` indicator was exactly backwards. Switch to `not page.has_next()` to match the intended semantics.

The context key is currently not consumed by any template (the pagination button uses `next_page_number <= total_pages`), so this has no visible effect — but the original code was misleading. Per @pablodiegoss: "Looks legitimate ... should make the current code cleaner and easier to read."

Closes #857

https://claude.ai/code/session_01XC1THLWgnGXGf5wgRhdyvB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XC1THLWgnGXGf5wgRhdyvB)_