### PR TITLE
Remove broken Post.get_absolute_url (#855)

### DIFF
--- a/src/blog/models.py
+++ b/src/blog/models.py
@@ -89,6 +89,3 @@ class Post(TimeStampedModel):
 
     def __str__(self):
         return self.title
-
-    def get_absolute_url(self):
-        return f"/memories/{self.slug}/"


### PR DESCRIPTION
The method referenced `self.slug`, but `Post` has no `slug` field, so any caller would hit `AttributeError`. It was never invoked anywhere in the codebase — leftover from development, per @pablodiegoss — so drop it instead of synthesizing a URL pattern.

Closes #855

https://claude.ai/code/session_01XC1THLWgnGXGf5wgRhdyvB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XC1THLWgnGXGf5wgRhdyvB)_