### PR TITLE
Remove unused ?user= path from profile view (#854)

### DIFF
--- a/src/users/views.py
+++ b/src/users/views.py
@@ -88,11 +88,6 @@ class ResetPasswordView(SuccessMessageMixin, PasswordResetView):
 @login_required
 @require_http_methods(["GET"])
 def profile(request):
-    user = request.GET.get("user")
-
-    if not user:
-        user = request.user
-
     profile = Profile.objects.prefetch_related(
         "exhibits__artworks",
         "artworks__exhibits",
@@ -103,7 +98,7 @@ def profile(request):
         "sounds__artworks",
         "sounds__ar_objects",
         "sounds__exhibits",
-    ).get(user=user)
+    ).get(user=request.user)
 
     ar_exhibits = (
         profile.exhibits.filter(exhibit_type=ExhibitTypes.AR).all().order_by("-created")


### PR DESCRIPTION
The `profile` view accepted `?user=` from the query string, used it as a raw `Profile` lookup key, then fell back to `request.user` if empty. Nothing in templates or tests hits the `?user=` path, so an invalid value would just crash the request.

Per @pablodiegoss, drop the dead branch instead of adding exception handling for something nobody calls. Profiles are auto-created on User `post_save`, so `.get(user=request.user)` after `@login_required` is safe.

Closes #854

https://claude.ai/code/session_01XC1THLWgnGXGf5wgRhdyvB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XC1THLWgnGXGf5wgRhdyvB)_