### PR TITLE
Use non-capturing group for me_hotsite URL (#851)

### DIFF
--- a/src/core/urls.py
+++ b/src/core/urls.py
@@ -63,7 +63,7 @@ urlpatterns = [
     path("sounds/upload/", sound_upload, name="sound-upload"),
     path("elements/", get_element, name="get-element"),
     re_path(
-        r"^(me|ME)\/?$",
+        r"^(?:me|ME)\/?$",
         me_hotsite,
         name="mitologia-extendida",
     ),

--- a/src/core/views/static_views.py
+++ b/src/core/views/static_views.py
@@ -19,7 +19,7 @@ def health_check(_):
     return JsonResponse({"status": "ok"}, status=200)
 
 
-def me_hotsite(request, _):
+def me_hotsite(request):
     return render(request, "core/ME/hotsite.html", {})
 
 


### PR DESCRIPTION
The regex `(me|ME)` captured the matched casing and forwarded it as a positional arg to `me_hotsite`, which absorbed it via an unused `_`. Switch to `(?:me|ME)` and drop the now-unneeded parameter so the view signature reflects what it actually receives. Pablo: LGTM, requires testing — verified `resolve('/me')` and `resolve('/ME/')` both land on `me_hotsite` with no extra args.

Closes #851

https://claude.ai/code/session_01XC1THLWgnGXGf5wgRhdyvB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XC1THLWgnGXGf5wgRhdyvB)_