### PR TITLE
Fix seeall context key typo in related_content (#850)

### DIFF
--- a/src/core/views/views.py
+++ b/src/core/views/views.py
@@ -660,7 +660,7 @@ def related_content(request):
             .distinct()
         )
 
-        ctx = {"artworks": artworks, "exhibits": exhibits, "seeall:": False}
+        ctx = {"artworks": artworks, "exhibits": exhibits, "seeall": False}
 
     elif element_type == "artwork":
         element = Artwork.objects.prefetch_related(
@@ -669,7 +669,7 @@ def related_content(request):
 
         exhibits = element.exhibits.all()
 
-        ctx = {"exhibits": exhibits, "seeall:": False}
+        ctx = {"exhibits": exhibits, "seeall": False}
 
     elif element_type == "sound":
         element = Sound.objects.prefetch_related(


### PR DESCRIPTION
Two of the three branches in `related_content` were writing `"seeall:"` (with a trailing colon) into the context dict, so the template's `{% if seeall == False %}` block fell through to the "not set" path. @pablodiegoss noted the default kept this from visibly breaking, but it's still a typo.

Closes #850

https://claude.ai/code/session_01XC1THLWgnGXGf5wgRhdyvB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XC1THLWgnGXGf5wgRhdyvB)_