### PR TITLE
Guard audio_description deletion with truthiness check (#849)

### DIFF
--- a/src/core/models.py
+++ b/src/core/models.py
@@ -608,6 +608,7 @@ def remove_source_file(sender, instance, **kwargs):
         instance.source.delete(False)
     if isinstance(instance, Object):
         instance.source.delete(False)
-        instance.audio_description.delete(False)
+        if instance.audio_description:
+            instance.audio_description.delete(False)
     if isinstance(instance, Sound):
         instance.file.delete(False)


### PR DESCRIPTION
Calling `.delete()` on an empty `FieldFile` is already a no-op in Django — which is why this never crashed in practice (Pablo: "probably LGTM, not sure as it never raised exceptions during development"). But the call is easier to read with an explicit guard, and it avoids invoking `storage.delete` / save on a missing file path.

Closes #849

https://claude.ai/code/session_01XC1THLWgnGXGf5wgRhdyvB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XC1THLWgnGXGf5wgRhdyvB)_