### PR TITLE
Return 404 instead of 500 on missing marker_preview (#847)

### DIFF
--- a/src/core/views/views.py
+++ b/src/core/views/views.py
@@ -189,7 +189,7 @@ def object_upload(request):
 @require_http_methods(["GET"])
 def marker_preview(request):
     marker_id = request.GET.get("id")
-    marker = Marker.objects.get(id=marker_id)
+    marker = get_object_or_404(Marker, id=marker_id)
     artwork = {
         "marker": marker,
         "augmented": marker,


### PR DESCRIPTION
`marker_preview` fetched `Marker.objects.get(id=marker_id)` directly, so an invalid or missing id raised `DoesNotExist`/`ValueError` through to a 500. Switch to the already-imported `get_object_or_404`. Pablo: LGTM.

Closes #847

https://claude.ai/code/session_01XC1THLWgnGXGf5wgRhdyvB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XC1THLWgnGXGf5wgRhdyvB)_