### PR TITLE
Use get_object_or_404 in edit_marker and edit_object (#846)

### DIFF
--- a/src/core/views/views.py
+++ b/src/core/views/views.py
@@ -226,7 +226,10 @@ def marker_upload(request):
 @login_required
 def edit_marker(request):
     index = request.GET.get("id", "-1")
-    model = Marker.objects.get(id=index)
+    model = get_object_or_404(Marker, id=index)
+
+    if model.owner != request.user.profile:
+        raise Http404
 
     model_data = {
         "source": model.source,
@@ -235,9 +238,6 @@ def edit_marker(request):
         "patt": model.patt,
         "title": model.title,
     }
-
-    if not model or model.owner != Profile.objects.get(user=request.user):
-        raise Http404
 
     if request.method == "POST":
         form = UploadMarkerForm(request.POST, request.FILES, instance=model)
@@ -263,7 +263,10 @@ def edit_marker(request):
 @login_required
 def edit_object(request):
     index = request.GET.get("id", "-1")
-    model = Object.objects.get(id=index)
+    model = get_object_or_404(Object, id=index)
+
+    if model.owner != request.user.profile:
+        raise Http404
 
     model_data = {
         "source": model.source,
@@ -272,8 +275,6 @@ def edit_object(request):
         "title": model.title,
         "thumbnail": model.thumbnail,
     }
-    if not model or model.owner != Profile.objects.get(user=request.user):
-        raise Http404
 
     if request.method == "POST":
         form = UploadObjectForm(request.POST, request.FILES, instance=model)


### PR DESCRIPTION
Both views called `Model.objects.get(id=index)` directly, so an invalid or missing id turned into a 500 (`DoesNotExist`/`ValueError`). Switch to `get_object_or_404` — Django 6 handles both cases — and drop the now-redundant `if not model` branch. The permission check still runs after the fetch, per @pablodiegoss's note that ownership lives on the row itself.

Tighten `request.user.profile` access to match the rest of the file instead of re-fetching `Profile`.

Closes #846

https://claude.ai/code/session_01XC1THLWgnGXGf5wgRhdyvB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XC1THLWgnGXGf5wgRhdyvB)_