### PR TITLE
Restrict ModalHTMLRenderer to retrieve action only (#712)

### DIFF
--- a/src/core/views/viewsets.py
+++ b/src/core/views/viewsets.py
@@ -18,7 +18,24 @@ from core.serializers import (
 )
 
 
-class MarkerViewset(ListModelMixin, RetrieveModelMixin, GenericViewSet):
+class ModalRetrieveOnlyMixin:
+    """Allow ModalHTMLRenderer only for the `retrieve` action.
+
+    The modal templates expect a single instance (`marker`, `object`, ...).
+    Letting ?format=modal through to `list` produces an HTTP 500 because no
+    template is associated with the paginated response.
+    """
+
+    def get_renderers(self):
+        renderers = super().get_renderers()
+        if getattr(self, "action", None) == "list":
+            return [r for r in renderers if not isinstance(r, ModalHTMLRenderer)]
+        return renderers
+
+
+class MarkerViewset(
+    ModalRetrieveOnlyMixin, ListModelMixin, RetrieveModelMixin, GenericViewSet
+):
     serializer_class = MarkerSerializer
     renderer_classes = [JSONRenderer, BrowsableAPIRenderer, ModalHTMLRenderer]
     queryset = (
@@ -39,7 +56,9 @@ class MarkerViewset(ListModelMixin, RetrieveModelMixin, GenericViewSet):
         return super().retrieve(request, *args, **kwargs)
 
 
-class ObjectViewset(ListModelMixin, RetrieveModelMixin, GenericViewSet):
+class ObjectViewset(
+    ModalRetrieveOnlyMixin, ListModelMixin, RetrieveModelMixin, GenericViewSet
+):
     serializer_class = ObjectSerializer
     renderer_classes = [JSONRenderer, BrowsableAPIRenderer, ModalHTMLRenderer]
     queryset = (
@@ -63,7 +82,9 @@ class ObjectViewset(ListModelMixin, RetrieveModelMixin, GenericViewSet):
         return super().retrieve(request, *args, **kwargs)
 
 
-class ArtworkViewset(ListModelMixin, RetrieveModelMixin, GenericViewSet):
+class ArtworkViewset(
+    ModalRetrieveOnlyMixin, ListModelMixin, RetrieveModelMixin, GenericViewSet
+):
     serializer_class = ArtworkSerializer
     renderer_classes = [JSONRenderer, BrowsableAPIRenderer, ModalHTMLRenderer]
     queryset = (
@@ -120,7 +141,9 @@ class ExhibitViewset(ListModelMixin, RetrieveModelMixin, GenericViewSet):
         return queryset
 
 
-class SoundViewset(ListModelMixin, RetrieveModelMixin, GenericViewSet):
+class SoundViewset(
+    ModalRetrieveOnlyMixin, ListModelMixin, RetrieveModelMixin, GenericViewSet
+):
     serializer_class = SoundSerializer
     renderer_classes = [JSONRenderer, BrowsableAPIRenderer, ModalHTMLRenderer]
 


### PR DESCRIPTION
## Summary

The Marker, Object, Artwork, and Sound viewsets all expose `ModalHTMLRenderer` for every action. Hitting the **list** endpoint with `?format=modal` — easy to do via the browsable API's format selector or a crawler clicking through — fell into the modal renderer with no template, surfacing as HTTP 500.

Added a small `ModalRetrieveOnlyMixin` that strips the modal renderer when the action is `list`. The list endpoint now does normal content negotiation as if modal weren't an option; DRF returns a clean `404 Not found.` for the unsupported format instead of crashing.

Verified manually for all four viewsets:
- `GET /api/v1/objects/?format=modal` → `404 {"detail":"Not found."}`
- `GET /api/v1/objects/` → `200 OK` (JSON list still works)
- `GET /api/v1/objects/1/?format=modal` → unchanged, still renders the modal template

## Test plan
- [ ] `make test` passes
- [ ] Existing modal-on-detail behaviour is preserved (verified locally; existing `test_retrieve_*_as_modal` tests pass when their fixture files are available)
- [ ] `/api/v1/objects/?format=modal` no longer crashes Django

Closes #712

https://claude.ai/code/session_01XC1THLWgnGXGf5wgRhdyvB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XC1THLWgnGXGf5wgRhdyvB)_