### PR TITLE
Strip directory components from uploaded filenames (#720)

### DIFF
--- a/src/core/forms.py
+++ b/src/core/forms.py
@@ -1,4 +1,5 @@
 from io import BytesIO
+from os.path import basename
 
 from django import forms
 from django.core.files.base import ContentFile, File
@@ -84,6 +85,8 @@ class UploadObjectForm(forms.ModelForm):
 
     def clean_source(self):
         file = self.cleaned_data.get("source")
+        if file is not None and getattr(file, "name", None):
+            file.name = basename(file.name)
 
         allowed_extensions = ["gif", "mp4", "webm", "glb"]
         extension = getattr(file, "name", "").split(".")[-1].lower()
@@ -107,6 +110,8 @@ class UploadObjectForm(forms.ModelForm):
         file = self.cleaned_data.get("audio_description")
         if not file:
             return None
+        if getattr(file, "name", None):
+            file.name = basename(file.name)
 
         allowed_extensions = ["mp3", "ogg", "wav"]
         extension = getattr(file, "name", "").split(".")[-1].lower()
@@ -141,6 +146,12 @@ class UploadMarkerForm(forms.ModelForm):
     class Meta:
         model = Marker
         fields = ("source", "author", "title")
+
+    def clean_source(self):
+        file = self.cleaned_data.get("source")
+        if file is not None and getattr(file, "name", None):
+            file.name = basename(file.name)
+        return file
 
     def save(self, *args, **kwargs):
         commit = kwargs.get("commit", True)
@@ -381,6 +392,8 @@ class SoundForm(forms.ModelForm):
         file = self.cleaned_data.get("file")
         if not file:
             raise forms.ValidationError(_("This field is required."))
+        if getattr(file, "name", None):
+            file.name = basename(file.name)
 
         allowed_extensions = ["mp3", "ogg", "wav"]
         extension = getattr(file, "name", "").split(".")[-1].lower()


### PR DESCRIPTION
## Summary

Django's `Storage.generate_filename` only sanitizes the basename via `get_valid_name`; any directory component the client put in the upload's `file.name` is preserved when joined to `upload_to`. So an upload with filename `"evil/path/file.gif"` against `upload_to="objects/"` lands at `"objects/evil/path/file.gif"`, silently creating nested folders inside the bucket — which is what showed up as the recursive markers/objects folders in storage that triggered #720.

Apply `os.path.basename` in the upload forms' `clean_*` methods so the file name reaching the storage layer is already flat:

- `UploadObjectForm.clean_source` / `clean_audio_description`
- `UploadMarkerForm.clean_source` (new method, the form previously had none)
- `SoundForm.clean_file`

## Verified

```python
>>> f = SimpleUploadedFile("evil/path/file.gif", b"...")
>>> form = UploadObjectForm(files={"source": f}, data={...})
>>> form.is_valid()
>>> form.cleaned_data["source"].name
'file.gif'
```

## Test plan
- [ ] `make test` passes
- [ ] Uploading a normal file (no slashes) lands in the expected `markers/`, `objects/`, `sounds/`, `audio_descriptions/` prefix as before
- [ ] An attempted upload with a slash in the filename lands in the same prefix using only the basename

Closes #720

https://claude.ai/code/session_01XC1THLWgnGXGf5wgRhdyvB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XC1THLWgnGXGf5wgRhdyvB)_