### PR TITLE
Restrict Safari-only warning to AR viewer (#696)

### DIFF
--- a/src/core/jinja2/core/arviewer.jinja2
+++ b/src/core/jinja2/core/arviewer.jinja2
@@ -28,6 +28,7 @@
             crossorigin="anonymous"></script>
     <script src="{{ static('js/bowser.js') }}"></script>
     <script src="{{ static('js/detect.js') }}"></script>
+    <script src="{{ static('js/safari-only-warning.js') }}"></script>
     <script src="{{ static('js/main.js') }}"></script>
     <body class="colorful">
         {% if content is defined %}

--- a/src/core/static/js/detect.js
+++ b/src/core/static/js/detect.js
@@ -1,4 +1,8 @@
-/* Change manifest href to use ios-manifest.json on IOS devices */
+/* Change manifest href to use ios-manifest.json on iOS devices.
+ * Safe to load on every page; the AR-only browser-compatibility
+ * warning lives in safari-only-warning.js and is loaded only by
+ * arviewer.jinja2.
+ */
 
 // Detects if device is on iOS
 const isIos = () => {
@@ -8,13 +12,4 @@ const isIos = () => {
 
 if (isIos()) {
     document.getElementById("manifest").href = "/static/ios-manifest.json";
-    const browser = bowser.getParser(window.navigator.userAgent)
-    const isValidBrowser = browser.satisfies({
-      safari: ">=9"
-    })
-    if(!isValidBrowser) {
-        alert(
-          "Desculpe, este aplicativo funciona apenas no navegador Safari :("
-        )
-    }
 }

--- a/src/core/static/js/safari-only-warning.js
+++ b/src/core/static/js/safari-only-warning.js
@@ -1,0 +1,21 @@
+/* Warn iOS users that the AR viewer requires Safari.
+ * Only relevant for the AR viewer (WebRTC + WebGL combination that
+ * historically only worked on iOS Safari), so this script is loaded
+ * exclusively by arviewer.jinja2. Loading it on the CMS would alert
+ * iPad/iPhone users on Chrome/Firefox unnecessarily, since the CMS
+ * pages render fine on any browser.
+ */
+
+(function () {
+    const userAgent = window.navigator.userAgent.toLowerCase();
+    const isIos = /iphone|ipad|ipod/.test(userAgent);
+    if (!isIos) return;
+
+    const browser = bowser.getParser(window.navigator.userAgent);
+    const isValidBrowser = browser.satisfies({ safari: ">=9" });
+    if (!isValidBrowser) {
+        alert(
+            "Desculpe, este aplicativo funciona apenas no navegador Safari :("
+        );
+    }
+})();


### PR DESCRIPTION
## Summary

`detect.js` was loaded from `base.jinja2`, so every iOS user on Chrome / Firefox / Edge / etc. got a `Desculpe, este aplicativo funciona apenas no navegador Safari :(` alert on every CMS page (My Creations, profile, exhibit list, etc.) — even though those pages render fine on any browser.

Split the script:

- **`detect.js`** keeps the iOS manifest swap (`/static/ios-manifest.json`). Still loaded everywhere from `base.jinja2` and `arviewer.jinja2` — needed for PWA install on iOS regardless of browser.
- **`safari-only-warning.js`** (new) holds the browser-compatibility alert and is loaded only by `arviewer.jinja2`, which is the page that actually requires Safari (WebRTC + WebGL + AR.js compatibility).

## Test plan
- [ ] Open `/profile/` on an iPhone in Chrome → no alert
- [ ] Open an AR viewer URL (`/<exhibit-slug>/`) on an iPhone in Chrome → alert still fires
- [ ] PWA manifest still resolves to `ios-manifest.json` on iOS for both CMS and AR viewer

Closes #696

https://claude.ai/code/session_01XC1THLWgnGXGf5wgRhdyvB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XC1THLWgnGXGf5wgRhdyvB)_