### PR TITLE
Restructure AR exhibit modal so "no artworks" never coexists with the list (#576)

### DIFF
--- a/src/core/jinja2/core/exhibit_create_ar.jinja2
+++ b/src/core/jinja2/core/exhibit_create_ar.jinja2
@@ -36,19 +36,17 @@
                 <div id="form-modal" class="modal">
                     <div id="artwork-modal" class="tab">
                         <h4 class="modal-title">{{ _("Select Artworks") }}</h4>
-                        {% with repository_list = artworks, element_type="artwork", selected=selected_artworks %}
-                            {% if repository_list|length > 0 %}
-                                <p class="gallery-title">{{ _("Choose from your repository") }}</p>
-                            {% else %}
-                                <section id="repo-{{ element_type }}" class="repository-list">
-                                    <p>{{ _("You have no Artworks. :c") }}</p>
-                                    <a href="{{ url('create-artwork') }}" class="button">{{ _("Create one") }}</a>
-                                </section>
-                            {% endif %}
-                            {% with repository_list = artworks, element_type="artwork", htmx="false" %}
+                        {% if artworks %}
+                            <p class="gallery-title">{{ _("Choose from your repository") }}</p>
+                            {% with repository_list = artworks, element_type="artwork", htmx="false", selected=selected_artworks %}
                                 {% include "core/components/item-list.jinja2" %}
                             {% endwith %}
-                        {% endwith %}
+                        {% else %}
+                            <section id="repo-artwork" class="repository-list">
+                                <p>{{ _("You have no Artworks. :c") }}</p>
+                                <a href="{{ url('create-artwork') }}" class="button">{{ _("Create one") }}</a>
+                            </section>
+                        {% endif %}
                         <a type="button"
                            type="button"
                            href="#close-modal"


### PR DESCRIPTION
## Summary

The artwork-selection modal in `exhibit_create_ar.jinja2` had two sibling structures:

1. An if/else block printing either "Choose from your repository" or "You have no Artworks. :c"
2. An **unconditional** include of `item-list.jinja2` that rendered the thumbnails right after

So the "no Artworks" copy and the artworks list weren't mutually exclusive at the template level — the include always ran. With certain queryset state (perhaps lazy evaluation or cache miss between the two `with` blocks rebinding `repository_list = artworks`), the "no artworks" branch could render alongside the populated list, which is exactly what the screenshot in #576 shows.

Restructure to make the two cases mutually exclusive at the template level: move the include inside the truthy branch, keep only the empty-state CTA in the else branch. This matches how `users/profile.jinja2` already structures every analogous section.

Also switch from `repository_list|length > 0` to plain `{% if artworks %}` — Django QuerySet's `__bool__` already calls `__len__`, so behaviour is identical, but it reads against the actual context variable instead of one rebound twice through `with` blocks.

## Test plan
- [ ] Create a new account, upload marker + object, create one artwork, then click "Create AR Exhibition" → "Select Artworks". The modal should show "Choose from your repository" and the single artwork, never both messages at once.
- [ ] Same flow without creating an artwork → modal should show only "You have no Artworks. :c" with the "Create one" CTA, no empty list section underneath.

Closes #576

https://claude.ai/code/session_01XC1THLWgnGXGf5wgRhdyvB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XC1THLWgnGXGf5wgRhdyvB)_