### PR TITLE
Use request host for exhibit URLs instead of hardcoded jandig.app (#822)

### DIFF
--- a/src/core/jinja2/core/exhibit_create_ar.jinja2
+++ b/src/core/jinja2/core/exhibit_create_ar.jinja2
@@ -25,7 +25,7 @@
                 <h3>{{ _("Exhibit Link") }}</h3>
                 <p class="gallery-title">{{ _("Your exhibit URL will look like this") }}</p>
                 <div style="display: flex; width: 100%">
-                    <label class="url-helper">https://jandig.app/</label>
+                    <label class="url-helper">{{ request.scheme }}://{{ request.get_host() }}/</label>
                     <p id="exhibit-slug-field" style="float: right; width: 65%">{{ form.visible_fields()[1] }}</p>
                 </div>
                 {{ form.visible_fields()[1] .errors }}

--- a/src/core/jinja2/core/exhibit_create_mr.jinja2
+++ b/src/core/jinja2/core/exhibit_create_mr.jinja2
@@ -25,7 +25,7 @@
                 <h3>{{ _("Exhibit Link") }}</h3>
                 <p class="gallery-title">{{ _("Your exhibit URL will look like this") }}</p>
                 <div style="display: flex; width: 100%">
-                    <label class="url-helper">https://jandig.app/</label>
+                    <label class="url-helper">{{ request.scheme }}://{{ request.get_host() }}/</label>
                     <p id="exhibit-slug-field" style="float: right; width: 65%">{{ form.visible_fields()[1] }}</p>
                 </div>
                 {{ form.visible_fields()[1] .errors }}

--- a/src/core/jinja2/core/exhibit_detail.jinja2
+++ b/src/core/jinja2/core/exhibit_detail.jinja2
@@ -7,12 +7,12 @@
         <div class="exhibit-detail-box flex">
             <h1 class="exhibit-name">{{ exhibit.name }}</h1>
             <p class="url">
-                https://jandig.app/<span>{{ exhibit.slug }}</span>
+                {{ request.scheme }}://{{ request.get_host() }}/<span>{{ exhibit.slug }}</span>
             </p>
             <p class="by">
                 {{ _("Created by ") }} <b>{{ exhibit.owner.user.username }}</b>
             </p>
-            <a href="https://jandig.app/{{ exhibit.slug }}" class="gotoExb">{{ _("See this exhibition") }}</a>
+            <a href="/{{ exhibit.slug }}" class="gotoExb">{{ _("See this exhibition") }}</a>
         </div>
         {% if artworks %}
             <h1 class="titArt">{{ _("Exhibition Artworks") }}</h1>


### PR DESCRIPTION
## Summary

Exhibit detail and create-exhibit pages were rendering URL previews and "share" links with a hardcoded `https://jandig.app/`. On dev, an exhibit at `dev.jandig.app/exhibit/?id=N` showed a share URL pointing at `https://jandig.app/<slug>/`, sending users away from the dev environment they were testing on.

Switch user-facing references to `{{ request.scheme }}://{{ request.get_host() }}/` so each environment links to itself. The "See this exhibition" anchor in `exhibit_detail.jinja2` uses a relative `/{slug}` path, which avoids the question entirely.

## Files changed

- `src/core/jinja2/core/exhibit_detail.jinja2`:
  - Display URL → `{{ request.scheme }}://{{ request.get_host() }}/<slug>`
  - Anchor href → `/{slug}` (relative)
- `src/core/jinja2/core/exhibit_create_ar.jinja2` / `exhibit_create_mr.jinja2`:
  - URL-helper preview label → dynamic host

## Test plan
- [ ] On `dev.jandig.app/exhibit/?id=…`: share link reads `dev.jandig.app/<slug>` and clicking goes to `dev.jandig.app/<slug>` (not production).
- [ ] On `jandig.app/exhibit/?id=…`: share link reads `jandig.app/<slug>` (unchanged behaviour).
- [ ] Create-exhibit "Your exhibit URL will look like this" preview uses the current host.

Closes #822

https://claude.ai/code/session_01XC1THLWgnGXGf5wgRhdyvB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XC1THLWgnGXGf5wgRhdyvB)_