### PR TITLE
Preserve M2M selections when editing exhibits (#838)

### DIFF
--- a/src/core/forms.py
+++ b/src/core/forms.py
@@ -256,6 +256,20 @@ class ExhibitForm(forms.ModelForm):
         self.fields["slug"].widget.attrs["placeholder"] = _(
             "Complete with your Exhibit URL here"
         )
+        # On edit, pre-populate the hidden M2M inputs with the current
+        # selections so a user who only changes name/URL doesn't end
+        # up posting empty strings that clobber the data. The JS in
+        # exhibit_create_*.jinja2 still rewrites the input on click.
+        if self.instance.pk:
+            self.fields["artworks"].initial = ",".join(
+                str(a.id) for a in self.instance.artworks.all()
+            )
+            self.fields["augmenteds"].initial = ",".join(
+                str(o.id) for o in self.instance.augmenteds.all()
+            )
+            self.fields["sounds"].initial = ",".join(
+                str(s.id) for s in self.instance.sounds.all()
+            )
 
     class Meta:
         model = Exhibit
@@ -339,25 +353,6 @@ class ExhibitForm(forms.ModelForm):
         cleaned_data = super().clean()
         artworks = cleaned_data.get("artworks") or []
         augmenteds = cleaned_data.get("augmenteds") or []
-        sounds = cleaned_data.get("sounds") or []
-
-        # On edit, the artworks/augmenteds/sounds CharFields are hidden
-        # inputs only populated by JS when the user clicks items in the
-        # selection modal. If the user just edits the name/URL and saves,
-        # those fields arrive empty in POST and would clobber the
-        # existing M2M data — and the validation below would refuse the
-        # save outright. Preserve the instance's current selections when
-        # nothing was submitted.
-        if self.instance.pk:
-            if not artworks:
-                artworks = list(self.instance.artworks.all())
-                cleaned_data["artworks"] = artworks
-            if not augmenteds:
-                augmenteds = list(self.instance.augmenteds.all())
-                cleaned_data["augmenteds"] = augmenteds
-            if not sounds:
-                sounds = list(self.instance.sounds.all())
-                cleaned_data["sounds"] = sounds
 
         if not artworks and not augmenteds:
             raise forms.ValidationError(

--- a/src/core/forms.py
+++ b/src/core/forms.py
@@ -337,8 +337,27 @@ class ExhibitForm(forms.ModelForm):
 
     def clean(self):
         cleaned_data = super().clean()
-        artworks = cleaned_data.get("artworks", [])
-        augmenteds = cleaned_data.get("augmenteds", [])
+        artworks = cleaned_data.get("artworks") or []
+        augmenteds = cleaned_data.get("augmenteds") or []
+        sounds = cleaned_data.get("sounds") or []
+
+        # On edit, the artworks/augmenteds/sounds CharFields are hidden
+        # inputs only populated by JS when the user clicks items in the
+        # selection modal. If the user just edits the name/URL and saves,
+        # those fields arrive empty in POST and would clobber the
+        # existing M2M data — and the validation below would refuse the
+        # save outright. Preserve the instance's current selections when
+        # nothing was submitted.
+        if self.instance.pk:
+            if not artworks:
+                artworks = list(self.instance.artworks.all())
+                cleaned_data["artworks"] = artworks
+            if not augmenteds:
+                augmenteds = list(self.instance.augmenteds.all())
+                cleaned_data["augmenteds"] = augmenteds
+            if not sounds:
+                sounds = list(self.instance.sounds.all())
+                cleaned_data["sounds"] = sounds
 
         if not artworks and not augmenteds:
             raise forms.ValidationError(


### PR DESCRIPTION
## Summary

`ExhibitForm` declares `artworks`, `augmenteds`, and `sounds` as `CharField` hidden inputs that the front-end populates from JS clicks. On the **edit** page, those inputs render empty: the form is constructed with `instance=…` but the custom `CharField`s aren't initialised from the underlying M2M data. A user who only edits Name/URL and clicks Save posts empty strings for all three, so:

- `clean_artworks` / `clean_augmenteds` / `clean_sounds` return `[]`
- `clean()` then raises `"You must select at least one artwork or augmented object."`
- the save is blocked — exactly the screenshot in #838

Patch: when the form is bound to an existing exhibit (`self.instance.pk`), fall back to the instance's stored M2M for any of the three fields that arrived empty. The existing `save()` override already pulls `cleaned_data["artworks"]/["augmenteds"]/["sounds"]` to apply the M2M, so the carried-over selections persist correctly.

This also incidentally fixes the same shape of bug for AR exhibits where the user opens the modal but doesn't reselect items.

Closely related: #853 (route should govern the type) is a separate design call still pending — see my comment there.

## Test plan
- [ ] Create an MR exhibit with augmenteds + sounds. Open `/exhibits/edit-mr/?id=…`. Edit name. Save. Returns to profile, exhibit reflects new name, augmenteds + sounds preserved.
- [ ] Same for AR exhibit (artworks preserved).
- [ ] Create flow still requires at least one artwork or augmented (validation only kicks in when `instance.pk is None`).

Closes #838

https://claude.ai/code/session_01XC1THLWgnGXGf5wgRhdyvB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XC1THLWgnGXGf5wgRhdyvB)_