### PR TITLE
Cap exhibits API list at 20 results (#717)

### DIFF
--- a/src/core/views/viewsets.py
+++ b/src/core/views/viewsets.py
@@ -1,5 +1,6 @@
 from django.db.models import Count
 from rest_framework.mixins import ListModelMixin, RetrieveModelMixin
+from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.renderers import (
     BrowsableAPIRenderer,
     JSONRenderer,
@@ -16,6 +17,19 @@ from core.serializers import (
     ObjectSerializer,
     SoundSerializer,
 )
+
+
+class ExhibitListPagination(LimitOffsetPagination):
+    """Cap the exhibit list endpoint at 20 results per request.
+
+    The MR/AR app feed pages through this endpoint; rendering all
+    exhibits at once is expensive on the device. 20 is the explicit
+    cap requested in #717 — both the default and the maximum, so a
+    client passing ?limit=999 still gets 20.
+    """
+
+    default_limit = 20
+    max_limit = 20
 
 
 class MarkerViewset(ListModelMixin, RetrieveModelMixin, GenericViewSet):
@@ -91,6 +105,7 @@ class ArtworkViewset(ListModelMixin, RetrieveModelMixin, GenericViewSet):
 
 class ExhibitViewset(ListModelMixin, RetrieveModelMixin, GenericViewSet):
     serializer_class = ExhibitSerializer
+    pagination_class = ExhibitListPagination
 
     def get_queryset(self):
         queryset = (


### PR DESCRIPTION
## Summary

`/api/v1/exhibits/` inherited DRF's default `LimitOffsetPagination` (`default_limit=20` via `PAGE_SIZE`), but `max_limit` was unset — so a client passing `?limit=999` could pull the whole table. The MR/AR app pages through this endpoint, and rendering hundreds of exhibits on-device is both slow and unwanted.

Add `ExhibitListPagination(LimitOffsetPagination)` with `default_limit=20` and `max_limit=20`, applied to `ExhibitViewset.pagination_class`. The hard cap holds regardless of the client's query string.

```python
class ExhibitListPagination(LimitOffsetPagination):
    default_limit = 20
    max_limit = 20
```

## Test plan
- [ ] `GET /api/v1/exhibits/` returns at most 20 results
- [ ] `GET /api/v1/exhibits/?limit=999` returns at most 20 results
- [ ] `GET /api/v1/exhibits/?offset=20` paginates correctly
- [ ] Other endpoints (markers, objects, sounds) still use the default pagination

Closes #717

https://claude.ai/code/session_01XC1THLWgnGXGf5wgRhdyvB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XC1THLWgnGXGf5wgRhdyvB)_