### PR TITLE
Silence Sphinx build warnings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,7 +42,10 @@ language = "pt_BR"
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = []
+# about.rst clashes with the Alabaster sidebar template `about.html`
+# (renaming it would also work; excluding keeps the file as a draft
+# document without breaking the build).
+exclude_patterns = ["about.rst"]
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -61,12 +64,6 @@ html_theme_options = {
     "logo": "logo.png",
     "github_user": "memeLab",
     "github_repo": "Jandig",
-    "html_sidebars": {
-        "**": [
-            "search.html",
-            "navigation.html",
-        ]
-    },
     "extra_nav_links": {
         "Official Site": "https://jandig.app",
         "Github": "https://github.com/memelab/Jandig",


### PR DESCRIPTION
## Summary

Two warnings on every Sphinx build:

```
WARNING: document isn't included in any toctree [toc.not_included]
WARNING: unsupported theme option 'html_sidebars' given
```

Both fixed:

- `about.rst` is a Portuguese description that isn't linked from `index`. Adding it to the toctree caused a name collision with Alabaster's `about.html` sidebar template and triggered a `RecursionError` in the theme renderer. Easiest fix: add it to `exclude_patterns` so the file stays in the repo as a draft without being built.
- `html_sidebars` was nested inside `html_theme_options` where Alabaster ignored it (hence the warning). The default Alabaster sidebar set is the intent here, so just drop the misplaced key — no behaviour change.

## Verified
```
$ rm -rf docs/_build && uv run sphinx-build -b html docs docs/_build/html
build succeeded.
```
Zero warnings, zero errors.

## Test plan
- [ ] Run `uv run sphinx-build -b html docs docs/_build/html` — finishes cleanly.
- [ ] `/docs/` site renders the same as before.

https://claude.ai/code/session_01XC1THLWgnGXGf5wgRhdyvB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XC1THLWgnGXGf5wgRhdyvB)_