### PR TITLE
Stop caching HTML in the service worker (#506)

### DIFF
--- a/src/core/jinja2/core/sw.js
+++ b/src/core/jinja2/core/sw.js
@@ -1,25 +1,36 @@
 importScripts('https://storage.googleapis.com/workbox-cdn/releases/3.6.1/workbox-sw.js');
 
+// Activate the new SW immediately so existing users stop being served
+// HTML from the old "cache everything" version (see #506).
+self.addEventListener('install', (event) => self.skipWaiting());
+self.addEventListener('activate', (event) => self.clients.claim());
+
 if (workbox) {
   console.log(`Yay! Workbox is loaded 🎉`);
 
+  // Cache only static assets — never HTML responses. Caching HTML
+  // produced cross-user state leaks and stale CSRF tokens (#506):
+  // when User B visited a page after User A had loaded it on the
+  // same browser, the SW could serve A's cached page (with A's
+  // username and CSRF token), and a subsequent setlang POST then
+  // failed with 403 because the CSRF token was bound to A's session.
+  //
+  // Static assets are origin-wide and don't carry per-user state,
+  // so they're safe to cache; let HTML always go to the network.
+
   workbox.routing.registerRoute(
-    new RegExp('.*'),
-    workbox.strategies.networkFirst()
-  );
-  workbox.routing.registerRoute(
-    new RegExp('.*\.js'),
+    /.*\.(?:png|jpg|jpeg|svg|gif|patt|webp|ico)$/,
     workbox.strategies.networkFirst()
   );
 
   workbox.routing.registerRoute(
-    '/',
+    /.*\.(?:js|css)$/,
     workbox.strategies.networkFirst()
   );
 
   workbox.routing.registerRoute(
-    /.*\.(?:png|jpg|jpeg|svg|gif|patt)/,
-    workbox.strategies.networkFirst()
+    /.*\.(?:woff|woff2|ttf|eot|otf)$/,
+    workbox.strategies.cacheFirst()
   );
 
   workbox.routing.registerRoute(


### PR DESCRIPTION
## Summary

The service worker registered `networkFirst()` for the catch-all `.*` regex, so **every** response — including authenticated HTML — was written to the workbox cache. On a shared browser this produced exactly the two symptoms in the issue:

1. After User B logged in, the SW could still serve User A's cached `/collection/` HTML — User B saw User A's username.
2. The cached page carried User A's **CSRF token**. When User B submitted the language selector form, the POST hit Django with A's token bound to no active session — `403 Forbidden`.

## Fix

`src/core/jinja2/core/sw.js`:

- Replace the catch-all routes with explicit static-asset matchers (images, JS/CSS, fonts, the workbox CDN). HTML now bypasses the SW entirely — the browser always hits the network and picks up the live username + a fresh CSRF token.
- Add `skipWaiting` + `clients.claim` so existing users get the new SW on their next page load instead of waiting for every tab to close.

## Test plan
- [ ] User A logs in on Chrome, visits `/collection/`. User B logs in on the same browser session and visits `/collection/` — sees their own username.
- [ ] User B opens the language selector and changes language → 302 → page reloads in the new locale (no 403).
- [ ] DevTools → Application → Service Workers shows the new worker activated; the workbox cache no longer contains HTML entries.
- [ ] Static assets (images, JS, CSS, fonts) still served from cache when offline.

Closes #506

https://claude.ai/code/session_01XC1THLWgnGXGf5wgRhdyvB

---
_Generated by [Claude Code](https://claude.ai/code/session_01XC1THLWgnGXGf5wgRhdyvB)_