### PR TITLE
fix(core): use request host in exhibit URL display so dev shows dev.jandig.app (#822)

### DIFF
--- a/src/core/jinja2/core/exhibit_create_ar.jinja2
+++ b/src/core/jinja2/core/exhibit_create_ar.jinja2
@@ -25,7 +25,7 @@
                 <h3>{{ _("Exhibit Link") }}</h3>
                 <p class="gallery-title">{{ _("Your exhibit URL will look like this") }}</p>
                 <div style="display: flex; width: 100%">
-                    <label class="url-helper">https://jandig.app/</label>
+                    <label class="url-helper">{{ request.scheme }}://{{ request.get_host() }}/</label>
                     <p id="exhibit-slug-field" style="float: right; width: 65%">{{ form.visible_fields()[1] }}</p>
                 </div>
                 {{ form.visible_fields()[1] .errors }}

--- a/src/core/jinja2/core/exhibit_create_mr.jinja2
+++ b/src/core/jinja2/core/exhibit_create_mr.jinja2
@@ -25,7 +25,7 @@
                 <h3>{{ _("Exhibit Link") }}</h3>
                 <p class="gallery-title">{{ _("Your exhibit URL will look like this") }}</p>
                 <div style="display: flex; width: 100%">
-                    <label class="url-helper">https://jandig.app/</label>
+                    <label class="url-helper">{{ request.scheme }}://{{ request.get_host() }}/</label>
                     <p id="exhibit-slug-field" style="float: right; width: 65%">{{ form.visible_fields()[1] }}</p>
                 </div>
                 {{ form.visible_fields()[1] .errors }}

--- a/src/core/jinja2/core/exhibit_detail.jinja2
+++ b/src/core/jinja2/core/exhibit_detail.jinja2
@@ -7,12 +7,12 @@
         <div class="exhibit-detail-box flex">
             <h1 class="exhibit-name">{{ exhibit.name }}</h1>
             <p class="url">
-                https://jandig.app/<span>{{ exhibit.slug }}</span>
+                {{ request.scheme }}://{{ request.get_host() }}/<span>{{ exhibit.slug }}</span>
             </p>
             <p class="by">
                 {{ _("Created by ") }} <b>{{ exhibit.owner.user.username }}</b>
             </p>
-            <a href="https://jandig.app/{{ exhibit.slug }}" class="gotoExb">{{ _("See this exhibition") }}</a>
+            <a href="/{{ exhibit.slug }}" class="gotoExb">{{ _("See this exhibition") }}</a>
         </div>
         {% if artworks %}
             <h1 class="titArt">{{ _("Exhibition Artworks") }}</h1>


### PR DESCRIPTION
Fixes #822. Three exhibit-related templates hardcoded `https://jandig.app/` for the URL display + share link, so on `dev.jandig.app` the user saw / copied a link pointing at production.

## Files

- `src/core/jinja2/core/exhibit_detail.jinja2`, display `{{ request.scheme }}://{{ request.get_host() }}/{slug}`; anchor `href` switched to relative `/{slug}` (zero-cost, more idiomatic, no host concern)
- `src/core/jinja2/core/exhibit_create_ar.jinja2` and `exhibit_create_mr.jinja2`, `url-helper` label uses the same dynamic host so the "Your exhibit URL will look like this" preview is honest on dev too

`request` is already provided to Jinja2 templates by Django (other templates in the repo use `request.user` / `request.LANGUAGE_CODE`).

`home_v2.jinja2` still has `https://jandig.app/docs/...` links, those go to the docs site which is canonical-on-prod, intentionally not touched.

## Test plan

- [x] 3-file template change, 4 lines +/-
- [x] No view/model code touched; production output unchanged because `request.get_host() == 'jandig.app'` there
- [x] Dev render now shows `dev.jandig.app/<slug>`